### PR TITLE
(Boilerplates) Fix/Enhancement Angular monopackage

### DIFF
--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -63,7 +63,7 @@ export class BoilerplateController {
 			return this._newAngularProject(params.name)
 		}).then(() => {
 			this._emitMessage('Rename angular project folder')
-			return this._renameFolder(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
+			return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
 		}).then(() => {
 			this._emitMessage('Build angular application')
 			return this.angularCli.execInFolder(params.output, 'build', [])
@@ -104,13 +104,23 @@ export class BoilerplateController {
 			this._emitMessage('construct monopackage structure')
 			return this._removeBoilerplatePackage(params.name)
 		}).then(() => {
+			return this._renameItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, '.gitignore2'))
+		}).then(() => {
 			return this._mergeBoilerplateProjectFolder(params.name)
 		}).then(() => {
 			return this._renameBoilerplateClientFolder()
 		}).then(() => {
-			return this.angularCli.moveE2eFolder()
+			return this._moveItem(path.join(this.app.path, 'e2e'), path.join(this.app.path, 'client', 'e2e'))
 		}).then(() => {
-			return this.angularCli.initNewConfig(params.name)
+			return this._moveItem(path.join(this.app.path, 'tslint.json'), path.join(this.app.path, 'client', 'tslint.json'))
+		}).then(() => {
+			return this._moveItem(path.join(this.app.path, 'tsconfig.json'), path.join(this.app.path, 'client', 'tsconfig.json'))
+		}).then(() => {
+			return this._moveItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, 'client', '.gitignore'))
+		}).then(() => {
+			return this._renameItem(path.join(this.app.path, '.gitignore2'), path.join(this.app.path, '.gitignore'))
+		}).then(() => {
+			return this.angularCli.initNewMonopackageConfig(params.name)
 		}).then(() => {
 			return this.angularCli.saveConfig()
 		}).then(() => {
@@ -237,7 +247,19 @@ export class BoilerplateController {
 		});
 	}
 
-	private _renameFolder(oldPath, newPath): Promise<void> {
+	private _moveItem(oldPath, newPath) {
+		return new Promise((resolve, reject) => {
+			return fse.move(oldPath, newPath, (err) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			})
+		});
+	}
+
+	private _renameItem(oldPath, newPath): Promise<void> {
 		return new Promise((resolve, reject) => {
 			fs.rename(path.join(oldPath), path.join(newPath), (err) => {
 				if (err) {
@@ -323,7 +345,7 @@ export class BoilerplateController {
 		])
 			.then(() => {
 				this._emitMessage('Rename React app folder')
-				return this._renameFolder(path.join(this.app.path, params.name), path.join(this.app.path, params.output));
+				return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output));
 			}).then(() => {
 				this._emitMessage('Add client config')
 				this.app.config.set({
@@ -383,7 +405,7 @@ export class BoilerplateController {
 				this._emitMessage('Generate Vue application')
 				return this._newVueProject(params.name);
 			}).then(() =>
-				this._renameFolder(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
+				this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
 			).then(() => {
 				this._emitMessage('Build vue application')
 				return this.vueCli.execVueCliServiceInFolder(params.output, 'build', [])

--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -104,6 +104,8 @@ export class BoilerplateController {
 			this._emitMessage('construct monopackage structure')
 			return this._removeBoilerplatePackage(params.name)
 		}).then(() => {
+			return this._deleteItem(path.join(this.app.path, params.name, '.git'))
+		}).then(() => {
 			return this._renameItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, '.gitignore2'))
 		}).then(() => {
 			return this._mergeBoilerplateProjectFolder(params.name)
@@ -243,6 +245,17 @@ export class BoilerplateController {
 						.then(() => resolve())
 						.catch(err => reject(err));
 				}
+			})
+		});
+	}
+
+	private _deleteItem(path) {
+		return new Promise((resolve, reject) => {
+			fs.unlink(path, (err) => {
+				if (err) {
+					reject(err);
+				}
+				resolve();
 			})
 		});
 	}

--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -62,6 +62,8 @@ export class BoilerplateController {
 			this.app.config.save();
 			return this._newAngularProject(params.name)
 		}).then(() => {
+			return this._deleteItem(path.join(this.app.path, params.name, '.git'))
+		}).then(() => {
 			this._emitMessage('Rename angular project folder')
 			return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
 		}).then(() => {


### PR DESCRIPTION
This pull request bring different enhancement on the angular monopackage structure:
- root .gitignore file is now preserved while merging folders
- generated angular .gitignore is now properly located in ./client instead of ./ 
- tsconfig.json/tslint.json files are now located in ./client instead of ./
=> simplify code because other tsconfigs files don't need to be modified anymore.
=> this structure is compatible with universal schematics
- angular.json.projects[project].root has know proper 'client' value
- lib/angular-cli.ts: rename initNewConfig() method to initNewMonopackageConfig()