### PR TITLE
Boilerplates: Clean controller + Fix angular/vue boilerplates

### DIFF
--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -60,6 +60,13 @@ export class BoilerplateController {
 			this._emitMessage('Build angular application');
 			return this.angularCli.exec(path.join(this.app.path, params.output), 'build', []);
 		}).then(() => {
+			const boilerplateProjectPath = path.join(this.app.path, params.output);
+			return this._fileToJson(path.join(boilerplateProjectPath, 'package.json'));
+		}).then((angularPackageJson: any) => {
+			angularPackageJson.scripts.watch = 'ng build --watch';
+			angularPackageJson.scripts.prod = 'ng build --prod';
+			return this.app.saveFile(path.join(this.app.path, params.output, 'package.json'), JSON.stringify(angularPackageJson, null, 2));
+		}).then(() => {
 			this.app.config.set({
 				src: params.output,
 				dist: `${params.output}/dist/${params.name}`,

--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -105,6 +105,8 @@ export class BoilerplateController {
 		}).then(() => {
 			return this._removeBoilerplatePackage(params.name);
 		}).then(() => {
+			return this._removeItemIfExist(path.join(this.app.path, params.name, 'readme.md'));
+		}).then(() => {
 			return this._removeItemIfExist(path.join(this.app.path, params.name, '.git'));
 		}).then(() => {
 			return this._renameItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, '.gitignore2'));
@@ -116,6 +118,8 @@ export class BoilerplateController {
 			return this._moveItem(path.join(this.app.path, 'e2e'), path.join(this.app.path, 'client', 'e2e'));
 		}).then(() => {
 			return this._moveItem(path.join(this.app.path, 'tslint.json'), path.join(this.app.path, 'client', 'tslint.json'));
+		}).then(() => {
+			return this._moveItem(path.join(this.app.path, '.editorconfig'), path.join(this.app.path, 'client', '.editorconfig'));
 		}).then(() => {
 			return this._moveItem(path.join(this.app.path, 'tsconfig.json'), path.join(this.app.path, 'client', 'tsconfig.json'));
 		}).then(() => {

--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -363,6 +363,7 @@ export class BoilerplateController {
 			const boilerplateProjectPath = path.join(this.app.path, projectName);
 			this._fileToJson(path.join(boilerplateProjectPath, 'package.json'))
 			.then((boilerplateProjectPackage: any) => {
+				delete boilerplateProjectPackage.scripts.start;
 				this.app.config.set(Object.assign({}, pkg.devDependencies, boilerplateProjectPackage.devDependencies), AppMode.DEVELOPMENT, ConfigType.DEPENDENCIES);
 				this.app.config.set(Object.assign({}, pkg.dependencies, boilerplateProjectPackage.dependencies), AppMode.PRODUCTION, ConfigType.DEPENDENCIES);
 				this.app.config.set(Object.assign({}, pkg.scripts, boilerplateProjectPackage.scripts, { watch: 'ng build --watch', prod: 'ng build --prod' }), this.app.mode, ConfigType.SCRIPTS);

--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -1,15 +1,15 @@
-import { App, AppMode, ConfigType } from '../../lib';
-import { Npm } from '../lib/npm';
-import { Npx } from '../lib/npx';
-import { AngularCli } from '../lib/angular-cli';
-import { VueCli } from '../lib/vue-cli';
-
-import { getPackageJson } from '../lib/getPackageJson';
-import { WebsocketInstance } from '../../lib/websocket';
-
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import * as path from 'path';
+
+import { App, AppMode, ConfigType } from '../../lib';
+import { Npm } from '../lib/npm';
+import { Npx } from '../lib/npx';
+import { getPackageJson } from '../lib/getPackageJson';
+import { WebsocketInstance } from '../../lib/websocket';
+
+import { AngularCli } from '../lib/angular-cli';
+import { VueCli } from '../lib/vue-cli';
 import { ReactScripts } from '../lib/react-scripts';
 
 export class BoilerplateController {
@@ -33,16 +33,6 @@ export class BoilerplateController {
 			.catch((err) => res.status(500).send(err.message));
 	}
 
-	private _emitMessage(message) {
-		const type = "boilerplate"
-		this.app.materiaApi.websocket.broadcast({ type, message: message })
-	}
-
-	private _emitError(err) {
-		const type = "boilerplate:error"
-		this.app.materiaApi.websocket.broadcast({ type, message: err.data })
-	}
-
 	initAngular(req, res) {
 		res.status(200).send({});
 		if (req.body && req.body.type === 'monopackage') {
@@ -53,22 +43,22 @@ export class BoilerplateController {
 	}
 
 	initDefaultAngular(params: { type: string, output: string, name: string }) {
-		this._emitMessage('install @angular/cli');
+		this._emitMessage('Install @angular/cli');
 
 		this.app.watcher.disable();
 		return this._installBoilerplateCli('@angular/cli').then(() => {
 			this._emitMessage('Generate angular project')
 			this.app.config.packageJson['scripts']['ng'] = 'ng';
 			this.app.config.save();
-			return this._newAngularProject(params.name)
+			return this._newAngularProject(['--routing', '--style=scss'], params.name);
 		}).then(() => {
-			return this._deleteItem(path.join(this.app.path, params.name, '.git'))
+			return this._removeItemIfExist(path.join(this.app.path, params.name, '.git'));
 		}).then(() => {
-			this._emitMessage('Rename angular project folder')
-			return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
+			this._emitMessage('Rename angular project folder');
+			return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output));
 		}).then(() => {
-			this._emitMessage('Build angular application')
-			return this.angularCli.execInFolder(params.output, 'build', [])
+			this._emitMessage('Build angular application');
+			return this.angularCli.exec(path.join(this.app.path, params.output), 'build', []);
 		}).then(() => {
 			this.app.config.set({
 				src: params.output,
@@ -87,7 +77,7 @@ export class BoilerplateController {
 
 			const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
 			const type = 'boilerplate:success';
-			this.app.materiaApi.websocket.broadcast({ type, client: client })
+			this.app.materiaApi.websocket.broadcast({ type, client: client });
 			this.app.watcher.enable();
 
 		}).catch(err => this._emitError(err));
@@ -98,41 +88,43 @@ export class BoilerplateController {
 
 		this.app.watcher.disable();
 		return this._installBoilerplateCli('@angular/cli').then(() => {
-			this._emitMessage('generate angular project')
+			this._emitMessage('Generate angular project');
 			this.app.config.packageJson['scripts']['ng'] = 'ng';
 			this.app.config.save();
-			return this._newAngularMonoPackageProject(params.name)
+			return this._newAngularProject(['--style=scss', '--routing', '--skip-install'], params.name);
 		}).then(() => {
-			this._emitMessage('construct monopackage structure')
-			return this._removeBoilerplatePackage(params.name)
+			this._emitMessage('Construct monopackage structure');
+			return this._mergeAngularPackage(params.name);
 		}).then(() => {
-			return this._deleteItem(path.join(this.app.path, params.name, '.git'))
+			return this._removeBoilerplatePackage(params.name);
 		}).then(() => {
-			return this._renameItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, '.gitignore2'))
+			return this._removeItemIfExist(path.join(this.app.path, params.name, '.git'));
 		}).then(() => {
-			return this._mergeBoilerplateProjectFolder(params.name)
+			return this._renameItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, '.gitignore2'));
 		}).then(() => {
-			return this._renameBoilerplateClientFolder()
+			return this._mergeBoilerplateProjectFolder(params.name);
 		}).then(() => {
-			return this._moveItem(path.join(this.app.path, 'e2e'), path.join(this.app.path, 'client', 'e2e'))
+			return this._renameBoilerplateClientFolder();
 		}).then(() => {
-			return this._moveItem(path.join(this.app.path, 'tslint.json'), path.join(this.app.path, 'client', 'tslint.json'))
+			return this._moveItem(path.join(this.app.path, 'e2e'), path.join(this.app.path, 'client', 'e2e'));
 		}).then(() => {
-			return this._moveItem(path.join(this.app.path, 'tsconfig.json'), path.join(this.app.path, 'client', 'tsconfig.json'))
+			return this._moveItem(path.join(this.app.path, 'tslint.json'), path.join(this.app.path, 'client', 'tslint.json'));
 		}).then(() => {
-			return this._moveItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, 'client', '.gitignore'))
+			return this._moveItem(path.join(this.app.path, 'tsconfig.json'), path.join(this.app.path, 'client', 'tsconfig.json'));
 		}).then(() => {
-			return this._renameItem(path.join(this.app.path, '.gitignore2'), path.join(this.app.path, '.gitignore'))
+			return this._moveItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, 'client', '.gitignore'));
 		}).then(() => {
-			return this.angularCli.initNewMonopackageConfig(params.name)
+			return this._renameItem(path.join(this.app.path, '.gitignore2'), path.join(this.app.path, '.gitignore'));
 		}).then(() => {
-			return this.angularCli.saveConfig()
+			return this.angularCli.initNewMonopackageConfig(params.name);
 		}).then(() => {
-			this._emitMessage('Install dependencies')
-			return this.npm.exec('install', [])
+			return this.angularCli.saveConfig();
 		}).then(() => {
-			this._emitMessage('Build angular application')
-			return this.angularCli.exec('build', [])
+			this._emitMessage('Install dependencies');
+			return this.npm.exec('install', []);
+		}).then(() => {
+			this._emitMessage('Build angular application');
+			return this.angularCli.exec(this.app.path, 'build', []);
 		}).then(() => {
 			this.app.config.set({
 				src: '',
@@ -151,66 +143,323 @@ export class BoilerplateController {
 
 			const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
 			const type = 'boilerplate:success';
-			this.app.materiaApi.websocket.broadcast({ type, client: client })
+			this.app.materiaApi.websocket.broadcast({ type, client: client });
 			this.app.watcher.enable();
 		}).catch(err => this._emitError(err));
 	}
 
-	private _installBoilerplateCli(packageName) {
+	initReact(req, res) {
+		res.status(200).send({});
+		this.app.watcher.disable();
+		const params = req.body;
+		if (! params.name) {
+			params.name = this.app.config.packageJson.name;
+		}
+		if (! params.output) {
+			params.output = 'client';
+		}
+		this._emitMessage('Create React application');
+		return this.npx.exec('create-react-app', [
+			params.name
+		]).then(() => {
+				this._emitMessage('Rename React app folder');
+				return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output));
+			}).then(() => {
+				this._emitMessage('Add client config');
+				this.app.config.set({
+					src: params.output,
+					dist: `${params.output}/build`,
+					buildEnabled: true,
+					scripts: {
+						build: "build",
+						watch: "watch",
+						prod: "prod"
+					},
+					autoWatch: false
+				}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				this._emitMessage('Add scripts to root package.json');
+				if (!this.app.config.packageJson['scripts']) {
+					this.app.config.packageJson['scripts'] = {};
+				}
+				this.app.config.packageJson['scripts']['build'] = "cd client && npm run build";
+				this.app.config.packageJson['scripts']['prod'] = "cd client && npm run build";
+				return this.app.config.save();
+			}).then(() => {
+				this._emitMessage('Build React application');
+				return this.npm.execInFolder(params.output, 'run-script', ['build']);
+			}).then(() => {
+				this.app.server.dynamicStatic.setPath(path.join(this.app.path, `${params.output}/build`));
+				const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				const type = 'boilerplate:success';
+				this.app.watcher.enable();
+				this.app.materiaApi.websocket.broadcast({ type, client: client });
+			}).catch(err => this._emitError(err));
+	}
+
+	initVue(req, res) {
+		res.status(200).send({});
+		if (req.body.type === 'monopackage') {
+			this.initVueMonoPackage(req.body);
+		} else {
+			this.initDefaultVue(req.body);
+		}
+	}
+
+	initDefaultVue(params) {
+
+		if (! params.name) {
+			params.name = this.app.config.packageJson.name;
+		}
+		if (! params.output) {
+			params.output = 'client';
+		}
+		this.app.watcher.disable();
+		this._emitMessage('Install @vue/cli');
+		return this._installBoilerplateCli('@vue/cli')
+			.then(() => {
+				this.app.config.packageJson['scripts']['vue'] = 'vue';
+				return this.app.config.save();
+			}).then(() => {
+				this._emitMessage('Generate Vue application');
+				return this._newVueProject(params.name);
+			}).then(() =>
+				this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
+			).then(() => {
+				this._emitMessage('Build vue application');
+				return this.vueCli.execVueCliService(path.join(this.app.path, params.output), 'build', []);
+			}).then(() => {
+				this.app.config.set({
+					src: params.output,
+					dist: `${params.output}/dist`,
+					buildEnabled: true,
+					scripts: {
+						build: "build",
+						prod: "build"
+					},
+					autoWatch: false
+				}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				this.app.server.dynamicStatic.setPath(path.join(this.app.path, params.output, 'dist'));
+				return this.app.config.save();
+			}).then(() => {
+				const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				const type = 'boilerplate:success';
+				this.app.materiaApi.websocket.broadcast({ type, client: client });
+			}).catch(err => this._emitError(err));
+	}
+
+	initVueMonoPackage(params) {
+		this.app.watcher.disable();
+		this._emitMessage('Install @vue/cli');
+
+		if (! params.name) {
+			params.name = this.app.config.packageJson.name;
+		}
+
+		return this._removeItemIfExist(path.join(this.app.path, 'package-lock.json'))
+			.then(() => this._removeItemIfExist(path.join(this.app.path, 'yarn.lock')))
+			.then(() => this._removeItemIfExist(path.join(this.app.path, 'node_modules')))
+			.then(() => this._installBoilerplateCli('@vue/cli'))
+			.then(() => {
+				this.app.config.packageJson['scripts']['vue'] = 'vue';
+				return this.app.config.save();
+			}).then(() => {
+				return this._renameItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, '.gitignore2'));
+			}).then(() => {
+				this._emitMessage('Generate Vue application');
+				return this._newVueProject(params.name);
+			}).then(() =>
+				this._mergeVuePackage(params.name)
+			).then(() => {
+				this._emitMessage('Generate monopackage structure');
+				return this._removeBoilerplatePackage(params.name);
+			})
+			.then(() => this._removeBoilerplateNodeModules(params.name))
+			.then(() => this._mergeBoilerplateProjectFolder(params.name))
+			.then(() => {
+				this._emitMessage('Create vue config file');
+				return this.app.saveFile(path.join(this.app.path, 'vue.config.js'), `module.exports = {
+	configureWebpack: {
+		entry: "./client/src/main.js"
+	},
+	outputDir: './client/dist'
+}`);
+			}).then(() =>
+				this._moveItem(path.join(this.app.path, 'src'), path.join(this.app.path, 'client', 'src'))
+			).then(() =>
+				this._moveItem(path.join(this.app.path, 'public'), path.join(this.app.path, 'client', 'public'))
+			).then(() =>
+				this._moveItem(path.join(this.app.path, '.gitignore'), path.join(this.app.path, 'client', '.gitignore'))
+			).then(() =>
+				this._renameItem(path.join(this.app.path, '.gitignore2'), path.join(this.app.path, '.gitignore'))
+			).then(() => {
+				this._emitMessage('Install dependencies');
+				return this.npm.exec('install', []);
+			}).then(() => {
+				this._emitMessage('Build vue application');
+				return this.vueCli.execVueCliService(this.app.path, 'build', []);
+			}).then(() => {
+				this.app.config.set({
+					src: '',
+					dist: 'client/dist',
+					buildEnabled: true,
+					scripts: {
+						build: "build",
+						prod: "build"
+					},
+					autoWatch: false
+				}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				this.app.server.dynamicStatic.setPath(path.join(this.app.path, 'client/dist'));
+				return this.app.config.save();
+			}).then(() => {
+				const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				const type = 'boilerplate:success';
+				this.app.materiaApi.websocket.broadcast({ type, client: client });
+			}).catch(err => this._emitError(err));
+	}
+
+	private _emitMessage(message) {
+		const type = "boilerplate";
+		this.app.materiaApi.websocket.broadcast({ type, message: message });
+	}
+
+	private _emitError(err) {
+		const type = "boilerplate:error";
+		this.app.materiaApi.websocket.broadcast({ type, message: err.data });
+	}
+
+	private _fileToJson(filePath) {
 		return new Promise((resolve, reject) => {
-			const name = packageName;
-			this.npm.exec('install', [name, '--save']).then(data => {
-				const pkg = this.app.config.packageJson
-				if (!pkg['scripts']) {
-					pkg['scripts'] = {};
+			fs.readFile(filePath, 'utf-8', (e, data) => {
+				if (e) {
+					reject(e);
+				} else {
+					resolve(JSON.parse(data));
 				}
-				if (!pkg['dependencies']) {
-					pkg['dependencies'] = {};
-				}
-				if (!pkg['devDependencies']) {
-					pkg['devDependencies'] = {};
-				}
-				getPackageJson(this.app, name).then(tmp => {
-					pkg['devDependencies'][name] = `~${tmp['version']}`;
-					this.app.config.packageJson = pkg;
-					this.app.config.save();
-					resolve();
-				}).catch(err => reject(err));
-			}).catch(err => reject(err));
+			});
 		});
 	}
 
-	private _newAngularProject(projectName?: string) {
-		return this.angularCli.exec('new', [
-			projectName ? projectName : this.app.config.packageJson.name,
-			'--style=scss',
-			'--routing'
-		]);
-	}
-
-	private _newAngularMonoPackageProject(projectName?: string) {
-		const name = projectName ? projectName : this.app.config.packageJson.name;
-		return this.angularCli.exec('new', [
-			name,
-			'--style=scss',
-			'--routing',
-			'--skip-install'
-		]).then(() =>
-			this._mergeAngularPackage(name)
-		);
+	private async _installBoilerplateCli(name) {
+		await this.npm.exec('install', [name, '--save']);
+		const tmp = await getPackageJson(this.app, name);
+		const pkg = this.app.config.packageJson;
+		if ( ! pkg['scripts'] ) {
+			pkg['scripts'] = {};
+		}
+		if ( ! pkg['dependencies'] ) {
+			pkg['dependencies'] = {};
+		}
+		if ( ! pkg['devDependencies'] ) {
+			pkg['devDependencies'] = {};
+		}
+		pkg['devDependencies'][name] = `~${tmp['version']}`;
+		this.app.config.packageJson = pkg;
+		return this.app.config.save();
 	}
 
 	private _mergeAngularPackage(projectName) {
 		return new Promise((resolve, reject) => {
-			const pkg = this.app.config.packageJson
+			const pkg = this.app.config.packageJson;
 			const boilerplateProjectPath = path.join(this.app.path, projectName);
-			this._fileToJson(path.join(boilerplateProjectPath, 'package.json')).then((boilerplateProjectPackage: any) => {
+			this._fileToJson(path.join(boilerplateProjectPath, 'package.json'))
+			.then((boilerplateProjectPackage: any) => {
 				this.app.config.set(Object.assign({}, pkg.devDependencies, boilerplateProjectPackage.devDependencies), AppMode.DEVELOPMENT, ConfigType.DEPENDENCIES);
 				this.app.config.set(Object.assign({}, pkg.dependencies, boilerplateProjectPackage.dependencies), AppMode.PRODUCTION, ConfigType.DEPENDENCIES);
 				this.app.config.set(Object.assign({}, pkg.scripts, boilerplateProjectPackage.scripts, { watch: 'ng build --watch', prod: 'ng build --prod' }), this.app.mode, ConfigType.SCRIPTS);
 				this.app.config.save();
 				resolve();
 			}).catch(err => reject(err));
+		});
+	}
+
+	private _mergeBoilerplateProjectFolder(projectName?: string) {
+		return new Promise((resolve, reject) => {
+			const projectPath = path.join(this.app.path, projectName ? projectName : this.app.config.packageJson.name);
+			fse.copy(projectPath, this.app.path, (err) => {
+				if (err) {
+					reject(err);
+				} else {
+					this._removeOldBoilerplateProjectDirectory(projectPath)
+						.then(() => resolve())
+						.catch(err => reject(err));
+				}
+			})
+		});
+	}
+
+	private _mergeVuePackage(projectName) {
+		const pkg = this.app.config.packageJson;
+		const boilerplateProjectPath = path.join(this.app.path, projectName);
+		return this._fileToJson(path.join(boilerplateProjectPath, 'package.json')).then((boilerplateProjectPackage: any) => {
+			this.app.config.set(Object.assign({}, pkg.devDependencies, boilerplateProjectPackage.devDependencies), AppMode.DEVELOPMENT, ConfigType.DEPENDENCIES);
+			this.app.config.set(Object.assign({}, pkg.dependencies, boilerplateProjectPackage.dependencies), AppMode.PRODUCTION, ConfigType.DEPENDENCIES);
+			this.app.config.set(Object.assign({}, pkg.scripts, boilerplateProjectPackage.scripts, { "vue-cli-service": "vue-cli-service" }), this.app.mode, ConfigType.SCRIPTS);
+			this.app.config.packageJson = Object.assign({},
+				this.app.config.packageJson,
+				{
+					eslintConfig: boilerplateProjectPackage.eslintConfig,
+					postcss: boilerplateProjectPackage.postcss,
+					browsersList: boilerplateProjectPackage.browsersList
+				}
+			);
+			return this.app.config.save();
+		})
+	}
+
+	private _moveItem(oldPath, newPath) {
+		return new Promise((resolve, reject) => {
+			return fse.move(oldPath, newPath, (err) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			})
+		});
+	}
+
+	private _newAngularProject(params: string[], projectName?: string) {
+		return this.angularCli.exec(this.app.path, 'new', [
+			projectName ? projectName : this.app.config.packageJson.name,
+			...params
+		]);
+	}
+
+	private _newVueProject(projectName) {
+		return this.vueCli.execVue('create', [
+			projectName,
+			'--git=false',
+			'--default'
+		]);
+	}
+
+	private _renameItem(oldPath, newPath): Promise<void> {
+		return new Promise((resolve, reject) => {
+			fs.rename(path.join(oldPath), path.join(newPath), (err) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+
+	private _renameBoilerplateClientFolder() {
+		return new Promise((resolve, reject) => {
+			fse.copy(path.join(this.app.path, 'src'), path.join(this.app.path, 'client', 'src'), (err) => {
+				if (err) {
+					reject(err);
+				} else {
+					fse.remove(path.join(this.app.path, 'src'), (err) => {
+						if (err) {
+							reject(err);
+						} else {
+							resolve();
+						}
+					});
+				}
+			});
 		});
 	}
 
@@ -236,73 +485,6 @@ export class BoilerplateController {
 			});
 		});
 	}
-	private _mergeBoilerplateProjectFolder(projectName?: string) {
-		return new Promise((resolve, reject) => {
-			const projectPath = path.join(this.app.path, projectName ? projectName : this.app.config.packageJson.name);
-			fse.copy(projectPath, this.app.path, (err) => {
-				if (err) {
-					reject(err);
-				} else {
-					this._removeOldBoilerplateProjectDirectory(projectPath)
-						.then(() => resolve())
-						.catch(err => reject(err));
-				}
-			})
-		});
-	}
-
-	private _deleteItem(path) {
-		return new Promise((resolve, reject) => {
-			fs.unlink(path, (err) => {
-				if (err) {
-					reject(err);
-				}
-				resolve();
-			})
-		});
-	}
-
-	private _moveItem(oldPath, newPath) {
-		return new Promise((resolve, reject) => {
-			return fse.move(oldPath, newPath, (err) => {
-				if (err) {
-					reject(err);
-				} else {
-					resolve();
-				}
-			})
-		});
-	}
-
-	private _renameItem(oldPath, newPath): Promise<void> {
-		return new Promise((resolve, reject) => {
-			fs.rename(path.join(oldPath), path.join(newPath), (err) => {
-				if (err) {
-					reject(err);
-				} else {
-					resolve();
-				}
-			});
-		});
-	}
-
-	private _renameBoilerplateClientFolder() {
-		return new Promise((resolve, reject) => {
-			fse.copy(path.join(this.app.path, 'src'), path.join(this.app.path, 'client', 'src'), (err) => {
-				if (err) {
-					reject(err);
-				} else {
-					fse.remove(path.join(this.app.path, 'src'), (err) => {
-						if (err) {
-							reject(err)
-						} else {
-							resolve();
-						}
-					})
-				}
-			});
-		});
-	}
 
 	private _removeOldBoilerplateProjectDirectory(projectPath) {
 		return new Promise((resolve, reject) => {
@@ -310,22 +492,10 @@ export class BoilerplateController {
 				if (err) {
 					reject(err);
 				}
-				resolve()
+				resolve();
 			});
 		});
 
-	}
-
-	private _fileToJson(packagePath) {
-		return new Promise((resolve, reject) => {
-			fs.readFile(packagePath, 'utf-8', (e, data) => {
-				if (e) {
-					reject(e);
-				} else {
-					resolve(JSON.parse(data));
-				}
-			});
-		});
 	}
 
 	private _removeItemIfExist(itemPath) {
@@ -342,232 +512,5 @@ export class BoilerplateController {
 				resolve();
 			}
 		});
-	}
-
-	initReact(req, res) {
-		res.status(200).send({});
-		this.app.watcher.disable();
-		const params = req.body;
-		if (! params.name) {
-			params.name = this.app.config.packageJson.name;
-		}
-		if (! params.output) {
-			params.output = 'client';
-		}
-		this._emitMessage('Create React application')
-		return this.npx.exec('create-react-app', [
-			params.name
-		])
-			.then(() => {
-				this._emitMessage('Rename React app folder')
-				return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output));
-			}).then(() => {
-				this._emitMessage('Add client config')
-				this.app.config.set({
-					src: params.output,
-					dist: `${params.output}/build`,
-					buildEnabled: true,
-					scripts: {
-						build: "build",
-						watch: "watch",
-						prod: "prod"
-					},
-					autoWatch: false
-				}, AppMode.DEVELOPMENT, ConfigType.CLIENT)
-				this._emitMessage('Add scripts to root package.json')
-				if (!this.app.config.packageJson['scripts']) {
-					this.app.config.packageJson['scripts'] = {};
-				}
-				this.app.config.packageJson['scripts']['build'] = "cd client && npm run build";
-				this.app.config.packageJson['scripts']['prod'] = "cd client && npm run build";
-				return this.app.config.save();
-			}).then(() => {
-				this._emitMessage('Build React application')
-				return this.npm.execInFolder(params.output, 'run-script', ['build'])
-			}).then(() => {
-				this.app.server.dynamicStatic.setPath(path.join(this.app.path, `${params.output}/build`));
-				const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
-				const type = 'boilerplate:success';
-				this.app.watcher.enable();
-				this.app.materiaApi.websocket.broadcast({ type, client: client })
-			}).catch(err => this._emitError(err));
-	}
-
-	initVue(req, res) {
-		res.status(200).send({});
-		if (req.body.type === 'monopackage') {
-			this.initVueMonoPackage(req.body);
-		} else {
-			this.initDefaultVue(req.body);
-		}
-	}
-
-	initDefaultVue(params) {
-
-		if (! params.name) {
-			params.name = this.app.config.packageJson.name;
-		}
-		if (! params.output) {
-			params.output = 'client';
-		}
-		this.app.watcher.disable();
-		this._emitMessage('Install @vue/cli')
-		return this._installBoilerplateCli('@vue/cli')
-			.then(() => {
-				this.app.config.packageJson['scripts']['vue'] = 'vue';
-				return this.app.config.save();
-			}).then(() => {
-				this._emitMessage('Generate Vue application')
-				return this._newVueProject(params.name);
-			}).then(() =>
-				this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
-			).then(() => {
-				this._emitMessage('Build vue application')
-				return this.vueCli.execVueCliServiceInFolder(params.output, 'build', [])
-			}).then(() => {
-				this.app.config.set({
-					src: params.output,
-					dist: `${params.output}/dist`,
-					buildEnabled: true,
-					scripts: {
-						build: "build",
-						prod: "build"
-					},
-					autoWatch: false
-				}, AppMode.DEVELOPMENT, ConfigType.CLIENT)
-				this.app.server.dynamicStatic.setPath(path.join(this.app.path, params.output, 'dist'));
-				return this.app.config.save();
-			}).then(() => {
-				const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
-				const type = 'boilerplate:success';
-				this.app.materiaApi.websocket.broadcast({ type, client: client })
-			}).catch(err => this._emitError(err));
-	}
-
-	initVueMonoPackage(params) {
-		this.app.watcher.disable();
-		this._emitMessage('Install @vue/cli')
-
-		if (! params.name) {
-			params.name = this.app.config.packageJson.name;
-		}
-
-		return this._removeItemIfExist(path.join(this.app.path, 'package-lock.json'))
-			.then(() => this._removeItemIfExist(path.join(this.app.path, 'yarn.lock')))
-			.then(() => this._removeItemIfExist(path.join(this.app.path, 'node_modules')))
-			.then(() => this._installBoilerplateCli('@vue/cli'))
-			.then(() => {
-				this.app.config.packageJson['scripts']['vue'] = 'vue';
-				return this.app.config.save();
-			}).then(() => {
-				this._emitMessage('Generate Vue application')
-				return this._newVueMonoPackageProject(params.name);
-			}).then(() => {
-				this._emitMessage('Generate monopackage structure')
-				return this._removeBoilerplatePackage(params.name)
-			})
-			.then(() => this._removeBoilerplateNodeModules(params.name))
-			.then(() => this._mergeBoilerplateProjectFolder(params.name))
-			.then(() => {
-				this._emitMessage('Create vue config file')
-				return this.app.saveFile(path.join(this.app.path, 'vue.config.js'), `module.exports = {
-	configureWebpack: {
-		entry: "./client/src/main.js"
-	},
-	outputDir: './client/dist'
-}`)
-			}).then(() => this._moveVueFolders())
-			.then(() => {
-				this._emitMessage('Install dependencies')
-				return this.npm.exec('install', [])
-			}).then(() => {
-				this._emitMessage('Build vue application')
-				return this.vueCli.execVueCliService('build', [])
-			}).then(() => {
-				this.app.config.set({
-					src: '',
-					dist: 'client/dist',
-					buildEnabled: true,
-					scripts: {
-						build: "build",
-						prod: "build"
-					},
-					autoWatch: false
-				}, AppMode.DEVELOPMENT, ConfigType.CLIENT)
-				this.app.server.dynamicStatic.setPath(path.join(this.app.path, 'client/dist'));
-				return this.app.config.save();
-			}).then(() => {
-				const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
-				const type = 'boilerplate:success';
-				this.app.materiaApi.websocket.broadcast({ type, client: client })
-			}).catch(err => this._emitError(err));
-	}
-
-	private _moveVueFolders() {
-		return new Promise((resolve, reject) => {
-			fse.copy(path.join(this.app.path, 'src'), path.join(this.app.path, 'client', 'src'), (err) => {
-				if (err) {
-					reject(err);
-				} else {
-					fse.remove(path.join(this.app.path, 'src'), (err) => {
-						if (err) {
-							reject(err)
-						} else {
-							fse.copy(path.join(this.app.path, 'public'), path.join(this.app.path, 'client', 'public'), (err) => {
-								if (err) {
-									reject(err);
-								} else {
-									fse.remove(path.join(this.app.path, 'public'), (err) => {
-										if (err) {
-											reject(err)
-										} else {
-											resolve();
-										}
-									})
-								}
-							});
-						}
-					})
-				}
-			});
-		});
-	}
-
-	private _newVueProject(projectName) {
-		return this.vueCli.execVue('create', [
-			projectName,
-			'--git=false',
-			'--default'
-		]);
-	}
-
-	private _newVueMonoPackageProject(projectName) {
-		return this.vueCli.execVue('create', [
-			this.app.config.packageJson.name,
-			'--git=false',
-			'--default'
-		]).then(() =>
-			this._mergeVuePackage(projectName)
-		);
-	}
-
-
-	private _mergeVuePackage(projectName) {
-		const pkg = this.app.config.packageJson
-		const boilerplateProjectPath = path.join(this.app.path, projectName);
-		return this._fileToJson(path.join(boilerplateProjectPath, 'package.json')).then((boilerplateProjectPackage: any) => {
-			this.app.config.set(Object.assign({}, pkg.devDependencies, boilerplateProjectPackage.devDependencies), AppMode.DEVELOPMENT, ConfigType.DEPENDENCIES);
-			this.app.config.set(Object.assign({}, pkg.dependencies, boilerplateProjectPackage.dependencies), AppMode.PRODUCTION, ConfigType.DEPENDENCIES);
-			this.app.config.set(Object.assign({}, pkg.scripts, boilerplateProjectPackage.scripts, { "vue-cli-service": "vue-cli-service" }), this.app.mode, ConfigType.SCRIPTS);
-			this.app.config.packageJson = Object.assign({},
-				this.app.config.packageJson,
-				{
-					eslintConfig: boilerplateProjectPackage.eslintConfig,
-					postcss: boilerplateProjectPackage.postcss,
-					browsersList: boilerplateProjectPackage.browsersList
-				}
-			)
-			return this.app.config.save();
-		})
 	}
 }

--- a/src/api/lib/angular-cli.ts
+++ b/src/api/lib/angular-cli.ts
@@ -9,74 +9,34 @@ export class AngularCli {
 
 	constructor(private app: App) { }
 
-	exec(command: string, params?: string[]): Promise<any> {
+	exec(cwd: string, command: string, params?: string[]): Promise<string> {
 		return new Promise((resolve, reject) => {
 			let data = '';
 			let stream = null;
-			if (fs.existsSync(path.join(this.app.path, "node_modules", ".bin", "ng"))) {
-				stream = execa(path.join(this.app.path, "node_modules", ".bin", "ng"), [command, ...params], {
-					cwd: this.app.path
+			if (fs.existsSync(path.join(cwd, "node_modules", ".bin", "ng"))) {
+				stream = execa(path.join(cwd, "node_modules", ".bin", "ng"), [command, ...params], {
+					cwd: cwd
 				});
-			} /*else {
-				stream = execa(path.join(path.resolve(), `resources/node_modules/.bin/npm`), [command, ...params], {
-					cwd: this.app.path
+				stream.stdout.on('data', d => {
+					data += d;
 				});
-			}*/
-			stream.stdout.on('data', d => {
-				data += d;
-			});
-			stream.stderr.on('data', (d) => {
-				data += d;
-			});
-
-			stream.on('close', (code) => {
-				if (code == 0) {
-					return resolve(data);
-				} else {
-					return reject({
-						code,
-						data
-					});
-				}
-			});
-
-		});
-	}
-
-	execInFolder(folder: string, command: string, params?: string[]): Promise<any> {
-		return new Promise((resolve, reject) => {
-			let data = '';
-			let stream = null;
-			if (fs.existsSync(path.join(this.app.path, folder,  "node_modules", ".bin", "ng"))) {
-				stream = execa(path.join(this.app.path, folder, "node_modules", ".bin", "ng"), [command, ...params], {
-					cwd: path.join(this.app.path, folder)
+				stream.stderr.on('data', (d) => {
+					data += d;
 				});
-			} /*else {
-				stream = execa(path.join(path.resolve(), `resources/node_modules/.bin/npm`), [command, ...params], {
-					cwd: this.app.path
+
+				stream.on('close', (code) => {
+					if (code == 0) {
+						return resolve(data);
+					} else {
+						return reject({
+							code,
+							data
+						});
+					}
 				});
-			}*/
-			stream.stdout.on('data', d => {
-				console.log(`Ng stdout: ${d}`);
-				data += d;
-			});
-			stream.stderr.on('data', (d) => {
-				console.log(`Ng stderr: ${d}`);
-				data += d;
-			});
-
-			stream.on('close', (code) => {
-				console.log(`Ng child process exited with code ${code}`);
-				if (code == 0) {
-					return resolve(data);
-				} else {
-					return reject({
-						code,
-						data
-					});
-				}
-			});
-
+			} else {
+				reject(new Error(`@angular/cli dependency not found in ${path.join(cwd, "node_modules")}`));
+			}
 		});
 	}
 

--- a/src/api/lib/vue-cli.ts
+++ b/src/api/lib/vue-cli.ts
@@ -17,106 +17,57 @@ export class VueCli {
 				stream = execa(path.join(this.app.path, "node_modules", ".bin", "vue"), [command, ...params], {
 					cwd: this.app.path
 				});
-			} /*else {
-				stream = execa(path.join(path.resolve(), `resources/node_modules/.bin/npm`), [command, ...params], {
-					cwd: this.app.path
+				stream.stdout.on('data', d => {
+					data += d;
 				});
-			}*/
-			stream.stdout.on('data', d => {
-				data += d;
-			});
-			stream.stderr.on('data', (d) => {
-				data += d;
-			});
+				stream.stderr.on('data', (d) => {
+					data += d;
+				});
 
-			stream.on('close', (code) => {
-				if (code == 0) {
-					return resolve(data);
-				} else {
-					return reject({
-						code,
-						data
-					});
-				}
-			});
-
+				stream.on('close', (code) => {
+					if (code == 0) {
+						return resolve(data);
+					} else {
+						return reject({
+							code,
+							data
+						});
+					}
+				});
+			} else {
+				reject(new Error(`vue dependency not found in ${this.app.path}`));
+			}
 		});
 	}
 
-	execVueCliService(command: string, params?: string[]): Promise<any> {
+	execVueCliService(cwd: string, command: string, params?: string[]): Promise<any> {
 		return new Promise((resolve, reject) => {
 			let data = '';
 			let stream = null;
-			if (fs.existsSync(path.join(this.app.path, "node_modules", ".bin", "vue-cli-service"))) {
-				stream = execa(path.join(this.app.path, "node_modules", ".bin", "vue-cli-service"), [command, ...params], {
-					cwd: this.app.path
+			if (fs.existsSync(path.join(cwd, "node_modules", ".bin", "vue-cli-service"))) {
+				stream = execa(path.join(cwd, "node_modules", ".bin", "vue-cli-service"), [command, ...params], {
+					cwd: cwd
+				});
+				stream.stdout.on('data', d => {
+					data += d;
+				});
+				stream.stderr.on('data', (d) => {
+					data += d;
+				});
+
+				stream.on('close', (code) => {
+					if (code == 0) {
+						return resolve(data);
+					} else {
+						return reject({
+							code,
+							data
+						});
+					}
 				});
 			} else {
-				reject(new Error('vue-cli-service not found'))
-			}/*else {
-				stream = execa(path.join(path.resolve(), `resources/node_modules/.bin/npm`), [command, ...params], {
-					cwd: this.app.path
-				});
-			}*/
-			stream.stdout.on('data', d => {
-				data += d;
-			});
-			stream.stderr.on('data', (d) => {
-				data += d;
-			});
-
-			stream.on('close', (code) => {
-				if (code == 0) {
-					return resolve(data);
-				} else {
-					return reject({
-						code,
-						data
-					});
-				}
-			});
-
+				reject(new Error(`vue-cli-service dependency not found in ${cwd}`));
+			}
 		});
 	}
-
-	execVueCliServiceInFolder(folder: string, command: string, params?: string[]): Promise<any> {
-		return new Promise((resolve, reject) => {
-			let data = '';
-			let stream = null;
-			if (fs.existsSync(path.join(this.app.path, folder, "node_modules", ".bin", "vue-cli-service"))) {
-				stream = execa(path.join(this.app.path, folder, "node_modules", ".bin", "vue-cli-service"), [command, ...params], {
-					cwd: path.join(this.app.path, folder)
-				});
-			} else {
-				reject(new Error('vue-cli-service not found'))
-			}/*else {
-				stream = execa(path.join(path.resolve(), `resources/node_modules/.bin/npm`), [command, ...params], {
-					cwd: this.app.path
-				});
-			}*/
-			stream.stdout.on('data', d => {
-				console.log(`Ng stdout: ${d}`);
-				data += d;
-			});
-			stream.stderr.on('data', (d) => {
-				console.log(`Ng stderr: ${d}`);
-				data += d;
-			});
-
-			stream.on('close', (code) => {
-				console.log(`Ng child process exited with code ${code}`);
-				if (code == 0) {
-					return resolve(data);
-				} else {
-					return reject({
-						code,
-						data
-					});
-				}
-			});
-
-		});
-	}
-
-
 }


### PR DESCRIPTION
This PR brings several improvement : 
- BoilerplateController has been cleaned and is more readable,
- Angular: ensure .git folder is deleted if generated,
- Angular/monopackage: generated readme.md is deleted before merge,
- Angular/monopackage: generated .editorconfig is now located in client folder,
- Angular/two packages structures: add 'watch' and 'prod' scripts,
- Vue/monopackage: preserved initial .gitingore and move generated .gitignore in client folder,
- AngularCliLib/VueCliLib: execInFolder() method has been merged with exec() method.