### PR TITLE
(Api/Controllers) Clean: harmonize/merge duplicated exec methods with…

### DIFF
--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -58,7 +58,7 @@ export class BoilerplateController {
 			return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output));
 		}).then(() => {
 			this._emitMessage('Build angular application');
-			return this.angularCli.exec(path.join(this.app.path, params.output), 'build', []);
+			return this.angularCli.exec('build', [], path.join(this.app.path, params.output));
 		}).then(() => {
 			const boilerplateProjectPath = path.join(this.app.path, params.output);
 			return this._fileToJson(path.join(boilerplateProjectPath, 'package.json'));
@@ -135,7 +135,7 @@ export class BoilerplateController {
 			return this.npm.exec('install', []);
 		}).then(() => {
 			this._emitMessage('Build angular application');
-			return this.angularCli.exec(this.app.path, 'build', []);
+			return this.angularCli.exec('build', []);
 		}).then(() => {
 			this.app.config.set({
 				src: '',
@@ -197,7 +197,7 @@ export class BoilerplateController {
 				return this.app.config.save();
 			}).then(() => {
 				this._emitMessage('Build React application');
-				return this.npm.execInFolder(params.output, 'run-script', ['build']);
+				return this.npm.exec('run-script', ['build'], path.join(this.app.path, params.output));
 			}).then(() => {
 				this.app.server.dynamicStatic.setPath(path.join(this.app.path, `${params.output}/build`));
 				const client = this.app.config.get(AppMode.DEVELOPMENT, ConfigType.CLIENT);
@@ -237,7 +237,7 @@ export class BoilerplateController {
 				this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output))
 			).then(() => {
 				this._emitMessage('Build vue application');
-				return this.vueCli.execVueCliService(path.join(this.app.path, params.output), 'build', []);
+				return this.vueCli.execVueCliService('build', [], path.join(this.app.path, params.output));
 			}).then(() => {
 				this.app.config.set({
 					src: params.output,
@@ -307,7 +307,7 @@ export class BoilerplateController {
 				return this.npm.exec('install', []);
 			}).then(() => {
 				this._emitMessage('Build vue application');
-				return this.vueCli.execVueCliService(this.app.path, 'build', []);
+				return this.vueCli.execVueCliService('build', []);
 			}).then(() => {
 				this.app.config.set({
 					src: '',
@@ -431,7 +431,7 @@ export class BoilerplateController {
 	}
 
 	private _newAngularProject(params: string[], projectName?: string) {
-		return this.angularCli.exec(this.app.path, 'new', [
+		return this.angularCli.exec('new', [
 			projectName ? projectName : this.app.config.packageJson.name,
 			...params
 		]);

--- a/src/api/controllers/client.ctrl.ts
+++ b/src/api/controllers/client.ctrl.ts
@@ -19,7 +19,7 @@ export class ClientController {
 		const conf = this.app.config.get<IClientConfig>(this.app.mode, ConfigType.CLIENT);
 		const script = conf.scripts && conf.scripts.watch ? conf.scripts.watch : 'watch';
 		await this._kill(this.npmProc);
-		const result = await this.npm.execInFolderBackground(join(this.app.path, conf.src), 'run-script', [script]);
+		const result = await this.npm.execInBackground('run-script', [script], join(this.app.path, conf.src));
 		this.npmProc = result.proc;
 		let last = -1;
 		let errors = [];
@@ -117,7 +117,7 @@ export class ClientController {
 			script = conf.scripts.prod;
 		}
 		if (script) {
-			this.npm.execInFolder(conf.src, 'run-script', [script], (data, error) => {
+			this.npm.exec('run-script', [script], join(this.app.path, conf.src), (data, error) => {
 				const progress = this._parseProgress(data);
 				if (progress) {
 					this.websocket.broadcast({
@@ -126,7 +126,7 @@ export class ClientController {
 						status: progress.progressStatus
 					});
 				}
-			}).then((res) => {
+			}).then(() => {
 				this.websocket.broadcast({
 					type: 'client:build:success',
 					hasStatic: this.app.server.hasStatic()

--- a/src/api/controllers/package-manager.ctrl.ts
+++ b/src/api/controllers/package-manager.ctrl.ts
@@ -18,7 +18,7 @@ export class PackageManagerController {
 		this.app.watcher.disable()
 
 		try {
-			this.npm.exec('install', [name, '--save'], (data, error) => {
+			this.npm.exec('install', [name, '--save'], null, (data, error) => {
 				this.app.logger.log(data);
 			}).then(data => {
 				this.app.watcher.enable()
@@ -46,7 +46,7 @@ export class PackageManagerController {
 	}
 
 	installAll(req, res) {
-		return this.npm.exec('install', [], (data, error) => {
+		return this.npm.exec('install', [], null, (data, error) => {
 			this.app.logger.log(data);
 		}).then(data => {
 			res.status(200).send({data});
@@ -62,7 +62,7 @@ export class PackageManagerController {
 			: req.params.dependency;
 
 		try {
-			this.npm.exec('uninstall', [name, '--save'], (data, error) => {
+			this.npm.exec('uninstall', [name, '--save'], null, (data, error) => {
 				this.app.logger.log(data);
 			}).then(data => {
 				this.app.watcher.enable()

--- a/src/api/lib/angular-cli.ts
+++ b/src/api/lib/angular-cli.ts
@@ -9,13 +9,13 @@ export class AngularCli {
 
 	constructor(private app: App) { }
 
-	exec(cwd: string, command: string, params?: string[]): Promise<string> {
+	exec(command: string, params?: string[], cwd?: string): Promise<string> {
 		return new Promise((resolve, reject) => {
 			let data = '';
 			let stream = null;
 			if (fs.existsSync(path.join(cwd, "node_modules", ".bin", "ng"))) {
 				stream = execa(path.join(cwd, "node_modules", ".bin", "ng"), [command, ...params], {
-					cwd: cwd
+					cwd: cwd ? cwd : this.app.path
 				});
 				stream.stdout.on('data', d => {
 					data += d;

--- a/src/api/lib/npm.ts
+++ b/src/api/lib/npm.ts
@@ -1,91 +1,26 @@
-// const npm = require('npm');
-// import { buffer } from './buffer';
-
-// import * as cp from 'child_process';
 import * as execa from 'execa';
 import { App } from '../../lib';
 import * as which from 'which';
-import * as path from 'path';
 
 export class Npm {
 	app: App;
-	constructor(private cwd: string, global = false) {}
+	constructor(private cwd: string) {}
 
 	enableLogger(app: App) { this.app = app; }
 
-	// useLocalNpm() { this.global = false; }
-	// useGlobalNpm() { this.global = true; }
-
-	execInBackground(command: string, params?: string[]) {
+	execInBackground(command: string, params?: string[], cwd?: string) {
 		if (this.app) {
 			this.app.logger.log(`NPM -> ${command} ${params.join(' ')}`);
 		}
 		return this.getNpmPath().then(npmPath => {
-			return execa(npmPath, [command, ...params], {
-				cwd: this.cwd
+			const npmProc = execa(npmPath, [command, ...params], {
+				cwd: cwd ? cwd : this.cwd
 			});
-		})
-	}
-
-	execInFolderBackground(folder: string, command: string, params?: string[]) {
-		if (this.app) {
-			this.app.logger.log(`NPM -> ${command} ${params.join(' ')}`);
-		}
-		return this.getNpmPath().then(npmPath => {
-			const npmProc = execa(npmPath, [command, ...params], {cwd: folder ? folder : this.cwd});
 			return { proc: npmProc };
 		});
 	}
 
-	exec(command: string, params?: string[], stream?: (data: any, error?: boolean) => void): Promise<any> {
-		return new Promise((resolve, reject) => {
-			let data = '';
-
-			return this.getNpmPath().then(npmPath => {
-				if (this.app) {
-					this.app.logger.log(`NPM -> ${command} ${params.join(' ')}`);
-					this.app.logger.log(`NPM binary used: ${npmPath}`)
-				}
-				const proc = execa(npmPath, [command, ...params], {
-					cwd: this.cwd
-				})
-				let working = true;
-				proc.stdout.on('data', d => {
-					if (this.app) {
-						this.app.logger.log(`npm stdout: ${d.toString()}`)
-					}
-					if (stream && working) {
-						stream(d.toString());
-					}
-					data += d;
-				});
-				proc.stderr.on('data', (d) => {
-					if (this.app) {
-						this.app.logger.log(`npm stderr: ${d.toString()}`)
-					}
-					if (stream && working) {
-						stream(d.toString(), true);
-					}
-					data += d;
-				});
-
-				proc.on('close', (code) => {
-					working = false;
-					if (code == 0) {
-						return resolve(data);
-					} else {
-						return reject({
-							code,
-							data
-						});
-					}
-				});
-			});
-		});
-	}
-
-
-	execInFolder(folder: string, command: string, params?: string[], stream?: (data: any, error?: boolean) => void): Promise<any> {
+	exec(command: string, params?: string[], cwd?: string, stream?: (data: any, error?: boolean) => void): Promise<any> {
 		return new Promise((resolve, reject) => {
 			let data = '';
 			return this.getNpmPath().then(npmPath => {
@@ -94,7 +29,7 @@ export class Npm {
 					this.app.logger.log(`NPM binary used: ${npmPath}`)
 				}
 				const proc = execa(npmPath, [command, ...params], {
-					cwd: path.join(this.cwd, folder)
+					cwd: cwd ? cwd : this.cwd
 				})
 				let working = true;
 				proc.stdout.on('data', d => {
@@ -134,16 +69,16 @@ export class Npm {
 	private getNpmPath() {
 		return new Promise((resolve, reject) => {
 			which('npm', (err, npmPath) => {
-				if (err && !npmPath) {
+				if (err && ! npmPath) {
 					if (this.app) {
 						this.app.logger.error(`npm -> path error: ${err}`)
 					}
-					return reject(err);
+					reject(err);
 				} else {
 					if (this.app) {
 						this.app.logger.log(`npm -> path: ${npmPath}`)
 					}
-					return resolve(npmPath)
+					resolve(npmPath)
 				}
 			});
 		});

--- a/src/api/lib/vue-cli.ts
+++ b/src/api/lib/vue-cli.ts
@@ -40,10 +40,13 @@ export class VueCli {
 		});
 	}
 
-	execVueCliService(cwd: string, command: string, params?: string[]): Promise<any> {
+	execVueCliService(command: string, params?: string[], cwd?: string): Promise<any> {
 		return new Promise((resolve, reject) => {
 			let data = '';
 			let stream = null;
+			if (! cwd) {
+				cwd = this.app.path;
+			}
 			if (fs.existsSync(path.join(cwd, "node_modules", ".bin", "vue-cli-service"))) {
 				stream = execa(path.join(cwd, "node_modules", ".bin", "vue-cli-service"), [command, ...params], {
 					cwd: cwd


### PR DESCRIPTION
This PR clean duplicated exec methods with 'folder' param. Now related methods have an optional param 'cwd' corresponding to the absolute path of the working directory. If no cwd is passed the current application path is used.
The following methods are concerned : npm.exec(), npm.execInBackground(), vue.execCliService(), angularCli.exec().