### PR TITLE
(Api/Endpoints) Fix endpoint controllers content loading

### DIFF
--- a/src/api/controllers/endpoints.ctrl.ts
+++ b/src/api/controllers/endpoints.ctrl.ts
@@ -34,7 +34,10 @@ export class EndpointsController {
 	}
 
 	loadController(req, res) {
-		let controllerName = req.query.name;
+		let controllerName = req.params.name;
+		if (req.params[0]) {
+			controllerName += req.params[0];
+		}
 		try {
 			let endpointPath = path.join(this.app.path, 'server', 'controllers');
 			const fromAddon = controllerName.split('@materia').length > 1;
@@ -45,7 +48,7 @@ export class EndpointsController {
 				stringArray.forEach((value, i) => {
 					if (i == 0) {
 						addonName += value;
-					} else {
+					} else if (i < stringArray.length - 1) {
 						addonName += '/' + value;
 					}
 				});
@@ -67,8 +70,7 @@ export class EndpointsController {
 				.toString();
 			res.status(200).send(code);
 		} catch (err) {
-			const error = JSON.parse(err);
-			res.status(500).json(error);
+			res.status(500).send(err);
 		}
 	}
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -167,7 +167,7 @@ export class MateriaApi {
 		 */
 		this.api.get('/materia/controllers', this.oauth.isAuth, this.endpointsCtrl.getControllers.bind(this.endpointsCtrl));
 		this.api.get('/materia/endpoints', this.oauth.isAuth, this.endpointsCtrl.getEndpoints.bind(this.endpointsCtrl));
-		this.api.get('/materia/controllers', this.oauth.isAuth, this.endpointsCtrl.loadController.bind(this.endpointsCtrl));
+		this.api.get('/materia/controllers/:name*', this.oauth.isAuth, this.endpointsCtrl.loadController.bind(this.endpointsCtrl));
 		this.api.post('/materia/endpoints/generate', this.oauth.isAuth, this.endpointsCtrl.generate.bind(this.endpointsCtrl));
 		this.api.post('/materia/endpoints/code', this.oauth.isAuth, this.endpointsCtrl.createCode.bind(this.endpointsCtrl));
 		this.api.post('/materia/endpoints/query', this.oauth.isAuth, this.endpointsCtrl.createQuery.bind(this.endpointsCtrl));


### PR DESCRIPTION
This PR brings bug fixes:
- Change duplicated api url to load controller content => `GET materia/controllers/:name*`
- Fix loadController() method in endpoint.ctrl.ts: retrieve correct controller path for addons controller
- Fix request error: send error with req.status(500).send() instead of json()