### PR TITLE
(Database/postgres) Fix change column type from text to integer

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -210,7 +210,7 @@ export class Database {
 					tmp = new Sequelize(null, null, null, opts)
 				}
 			} catch (e) {
-				reject(e)
+				return reject(e)
 			}
 			d.add(tmp.query)
 			d.on('error', (e) => {

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -210,15 +210,15 @@ export class Database {
 					tmp = new Sequelize(null, null, null, opts)
 				}
 			} catch (e) {
-				return reject(e)
+				reject(e)
 			}
 			d.add(tmp.query)
 			d.on('error', (e) => {
 				d.remove(tmp.query)
-				return reject(e)
+				reject(e)
 			})
 			d.run(() => {
-				return tmp.authenticate().then(() => {
+				tmp.authenticate().then(() => {
 					tmp.close()
 					accept()
 				}).catch((e) => { reject(e) })

--- a/src/lib/entities/db-entity.ts
+++ b/src/lib/entities/db-entity.ts
@@ -229,17 +229,12 @@ export class DBEntity extends Entity {
 					return this.app.database.interface.dropConstraint(this.name, { field: fieldobj.name, type: "references" })
 				}
 			}).then(() => {
-				return this.app.database.interface.castColumnType(this.name, fieldobj.name, oldfield.type, field.type)
-			}).then((castedType) => {
-				if (castedType) {
-					delete field.type
-				}
 				let dbfield = this.app.database.interface.fieldToColumn(field)
 				if (Object.keys(dbfield).length == 0)
 					return Promise.resolve()
 
 				// sequelize changeColumn must constain type and nullable
-				if (!dbfield.type) {
+				if ( ! dbfield.type ) {
 					field.type = oldfield.type
 				}
 				if (dbfield.allowNull == undefined) {
@@ -257,7 +252,7 @@ export class DBEntity extends Entity {
 				}
 
 				let p = Promise.resolve()
-				if (field.required && !field.default && field.defaultValue) {
+				if (field.required && ! field.default && field.defaultValue) {
 					p = p.then(() => {
 						field.default = true
 						field.required = false


### PR DESCRIPTION
This PR remove an old fix for changing column types for dialect postgres, which needed a cast. It wasn't working anymore when changing type 'text' to 'number' for postgres. It seems to have been fixed in sequelize, because by removing this fix I am able to change postgresSQL column type.
