### PR TITLE
Client configuration refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "materia": "./cli/index.js"
   },
   "dependencies": {
-    "@materia/interfaces": "1.0.0-beta.1",
+    "@materia/interfaces": "^1.0.0-beta.2",
     "body-parser": "^1.17.2",
     "chalk": "^2.3.1",
     "chokidar": "^2.0.4",

--- a/src/api/controllers/app.ctrl.ts
+++ b/src/api/controllers/app.ctrl.ts
@@ -66,13 +66,15 @@ export class AppController {
 			}
 
 			const clientToSave: IClientConfig = {
-				src: client.src
+				www: client.www
 			}
-			if (client.enabled && client.build && client.build.enabled && client.dist && client.dist.length > 0 && client.src !== client.dist) {
-				clientToSave.dist = client.dist
-				this.app.server.dynamicStatic.setPath(path.join(this.app.path, client.dist));
-			} else if (client.enabled && client.src) {
-				this.app.server.dynamicStatic.setPath(path.join(this.app.path, client.src));
+			if (client.www) {
+				this.app.server.dynamicStatic.setPath(path.join(this.app.path, client.www));
+			}
+			if (client.packageJson) {
+				clientToSave.packageJsonPath = client.packageJsonPath
+			} else if (client.build && client.build.enabled) {
+				clientToSave.build = true;
 			}
 			if (client.scripts && (client.scripts.build || client.scripts.watch || client.scripts.prod)) {
 				clientToSave.scripts = {}

--- a/src/api/controllers/app.ctrl.ts
+++ b/src/api/controllers/app.ctrl.ts
@@ -55,7 +55,7 @@ export class AppController {
 		}
 	}
 
-	private saveClientSettings(app, settings) {
+	private saveClientSettings(app: App, settings: any) {
 		if (settings.client) {
 			const client = settings.client;
 			if (client.packageJson) {
@@ -70,28 +70,31 @@ export class AppController {
 			}
 			if (client.www) {
 				this.app.server.dynamicStatic.setPath(path.join(this.app.path, client.www));
-			}
-			if (client.packageJson) {
-				clientToSave.packageJsonPath = client.packageJsonPath
-			} else if (client.build && client.build.enabled) {
-				clientToSave.build = true;
-			}
-			if (client.scripts && (client.scripts.build || client.scripts.watch || client.scripts.prod)) {
-				clientToSave.scripts = {}
-				if (client.scripts.build) {
-					clientToSave.scripts.build = client.scripts.build;
+				if (client.packageJsonPath) {
+					clientToSave.packageJsonPath = client.packageJsonPath
+				} else if (client.build && client.build.enabled) {
+					clientToSave.build = true;
 				}
-				if (client.scripts.watch) {
-					clientToSave.scripts.watch = client.scripts.watch;
+				if (client.scripts && (client.scripts.build || client.scripts.watch || client.scripts.prod)) {
+					clientToSave.scripts = {}
+					if (client.scripts.build) {
+						clientToSave.scripts.build = client.scripts.build;
+					}
+					if (client.scripts.watch) {
+						clientToSave.scripts.watch = client.scripts.watch;
+					}
+					if (client.scripts.prod) {
+						clientToSave.scripts.prod = client.scripts.prod;
+					}
 				}
-				if (client.scripts.prod) {
-					clientToSave.scripts.prod = client.scripts.prod;
+				if (client.autoWatch) {
+					clientToSave.autoWatch = client.autoWatch;
 				}
+				app.config.set(clientToSave, 'dev', ConfigType.CLIENT);
+			} else {
+				app.config.delete(ConfigType.CLIENT);
 			}
-			if (client.autoWatch) {
-				clientToSave.autoWatch = client.autoWatch;
-			}
-			app.config.set(clientToSave, 'dev', ConfigType.CLIENT);
+
 		}
 
 	}

--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import * as path from 'path';
+import { IClientConfig } from '@materia/interfaces';
 
 import { App, AppMode, ConfigType } from '../../lib';
 import { Npm } from '../lib/npm';
@@ -67,17 +68,18 @@ export class BoilerplateController {
 			angularPackageJson.scripts.prod = 'ng build --prod';
 			return this.app.saveFile(path.join(this.app.path, params.output, 'package.json'), JSON.stringify(angularPackageJson, null, 2));
 		}).then(() => {
-			this.app.config.set({
-				src: params.output,
-				dist: `${params.output}/dist/${params.name}`,
-				buildEnabled: true,
+			const clientConfig: IClientConfig = {
+				packageJsonPath: params.output,
+				www: `${params.output}/dist/${params.name}`,
+				build: true,
 				scripts: {
 					build: "build",
 					watch: "watch",
 					prod: "prod"
 				},
 				autoWatch: false
-			}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+			};
+			this.app.config.set(clientConfig, AppMode.DEVELOPMENT, ConfigType.CLIENT);
 			return this.app.config.save();
 		}).then(() => {
 			this.app.server.dynamicStatic.setPath(path.join(this.app.path, `${params.output}/dist/${params.name}`));
@@ -137,17 +139,17 @@ export class BoilerplateController {
 			this._emitMessage('Build angular application');
 			return this.angularCli.exec('build', []);
 		}).then(() => {
-			this.app.config.set({
-				src: '',
-				dist: 'client/dist',
-				buildEnabled: true,
+			const clientConfig: IClientConfig = {
+				www: 'client/dist',
+				build: true,
 				scripts: {
 					build: "build",
 					watch: "watch",
 					prod: "prod"
 				},
 				autoWatch: false
-			}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+			};
+			this.app.config.set(clientConfig, AppMode.DEVELOPMENT, ConfigType.CLIENT);
 			return this.app.config.save();
 		}).then(() => {
 			this.app.server.dynamicStatic.setPath(path.join(this.app.path, 'client/dist'));
@@ -163,10 +165,10 @@ export class BoilerplateController {
 		res.status(200).send({});
 		this.app.watcher.disable();
 		const params = req.body;
-		if (! params.name) {
+		if ( ! params.name ) {
 			params.name = this.app.config.packageJson.name;
 		}
-		if (! params.output) {
+		if ( ! params.output ) {
 			params.output = 'client';
 		}
 		this._emitMessage('Create React application');
@@ -177,19 +179,20 @@ export class BoilerplateController {
 				return this._renameItem(path.join(this.app.path, params.name), path.join(this.app.path, params.output));
 			}).then(() => {
 				this._emitMessage('Add client config');
-				this.app.config.set({
-					src: params.output,
-					dist: `${params.output}/build`,
-					buildEnabled: true,
+				const clientConfig: IClientConfig = {
+					packageJsonPath: params.output,
+					www: `${params.output}/build`,
+					build: true,
 					scripts: {
 						build: "build",
 						watch: "watch",
 						prod: "prod"
 					},
 					autoWatch: false
-				}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				};
+				this.app.config.set(clientConfig, AppMode.DEVELOPMENT, ConfigType.CLIENT);
 				this._emitMessage('Add scripts to root package.json');
-				if (!this.app.config.packageJson['scripts']) {
+				if ( ! this.app.config.packageJson['scripts'] ) {
 					this.app.config.packageJson['scripts'] = {};
 				}
 				this.app.config.packageJson['scripts']['build'] = "cd client && npm run build";
@@ -218,10 +221,10 @@ export class BoilerplateController {
 
 	initDefaultVue(params) {
 
-		if (! params.name) {
+		if ( ! params.name ) {
 			params.name = this.app.config.packageJson.name;
 		}
-		if (! params.output) {
+		if ( ! params.output ) {
 			params.output = 'client';
 		}
 		this.app.watcher.disable();
@@ -239,16 +242,17 @@ export class BoilerplateController {
 				this._emitMessage('Build vue application');
 				return this.vueCli.execVueCliService('build', [], path.join(this.app.path, params.output));
 			}).then(() => {
-				this.app.config.set({
-					src: params.output,
-					dist: `${params.output}/dist`,
-					buildEnabled: true,
+				const clientConfig: IClientConfig = {
+					packageJsonPath: params.output,
+					www: `${params.output}/dist`,
+					build: true,
 					scripts: {
 						build: "build",
 						prod: "build"
 					},
 					autoWatch: false
-				}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				}
+				this.app.config.set(clientConfig, AppMode.DEVELOPMENT, ConfigType.CLIENT);
 				this.app.server.dynamicStatic.setPath(path.join(this.app.path, params.output, 'dist'));
 				return this.app.config.save();
 			}).then(() => {
@@ -262,7 +266,7 @@ export class BoilerplateController {
 		this.app.watcher.disable();
 		this._emitMessage('Install @vue/cli');
 
-		if (! params.name) {
+		if ( ! params.name ) {
 			params.name = this.app.config.packageJson.name;
 		}
 
@@ -309,16 +313,16 @@ export class BoilerplateController {
 				this._emitMessage('Build vue application');
 				return this.vueCli.execVueCliService('build', []);
 			}).then(() => {
-				this.app.config.set({
-					src: '',
-					dist: 'client/dist',
-					buildEnabled: true,
+				const clientConfig: IClientConfig = {
+					www: 'client/dist',
+					build: true,
 					scripts: {
 						build: "build",
 						prod: "build"
 					},
 					autoWatch: false
-				}, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				}
+				this.app.config.set(clientConfig, AppMode.DEVELOPMENT, ConfigType.CLIENT);
 				this.app.server.dynamicStatic.setPath(path.join(this.app.path, 'client/dist'));
 				return this.app.config.save();
 			}).then(() => {

--- a/src/api/controllers/boilerplate.ctrl.ts
+++ b/src/api/controllers/boilerplate.ctrl.ts
@@ -30,6 +30,13 @@ export class BoilerplateController {
 
 	initMinimal(req, res) {
 		this.app.initializeStaticDirectory()
+			.then(() => {
+				const clientConfig: IClientConfig = {
+					www: 'client'
+				}
+				this.app.config.set(clientConfig, AppMode.DEVELOPMENT, ConfigType.CLIENT);
+				return this.app.config.save();
+			})
 			.then(() => res.status(200).json({ init: true }))
 			.catch((err) => res.status(500).send(err.message));
 	}

--- a/src/api/controllers/client.ctrl.ts
+++ b/src/api/controllers/client.ctrl.ts
@@ -19,7 +19,7 @@ export class ClientController {
 		const conf = this.app.config.get<IClientConfig>(this.app.mode, ConfigType.CLIENT);
 		const script = conf.scripts && conf.scripts.watch ? conf.scripts.watch : 'watch';
 		await this._kill(this.npmProc);
-		const result = await this.npm.execInBackground('run-script', [script], join(this.app.path, conf.src));
+		const result = await this.npm.execInBackground('run-script', [script], join(this.app.path, conf.packageJsonPath));
 		this.npmProc = result.proc;
 		let last = -1;
 		let errors = [];
@@ -117,7 +117,7 @@ export class ClientController {
 			script = conf.scripts.prod;
 		}
 		if (script) {
-			this.npm.exec('run-script', [script], join(this.app.path, conf.src), (data, error) => {
+			this.npm.exec('run-script', [script], join(this.app.path, conf.packageJsonPath), (data, error) => {
 				const progress = this._parseProgress(data);
 				if (progress) {
 					this.websocket.broadcast({

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -45,26 +45,32 @@ export class Client {
 			}
 		}*/
 		if ( ! this.config ) {
-			this.config = { buildEnabled: false }
+			this.config = { build: false }
 			this.app.logger.log(` │ └── ${chalk.bold('No build scripts detected')}`)
 		}
 
-		/*if ( ! this.config.build ) {
-			this.config.build = 'web'
-		}*/
-		if ( ! this.config.src ) {
-			this.config.src = 'client'
+		if ( ! this.config.www ) {
+			this.config.www = '';
+		} else {
+			this.app.logger.log(` │ └── Static folder ${chalk.bold('./' + this.config.www)} detected`)
 		}
-		if ( ! this.config.dist) {
-			this.config.dist = this.config.src
+		if ( ! this.config.packageJsonPath) {
+			this.config.packageJsonPath = '';
+		} else {
+			this.config.build = true;
+		}
+		if (this.config.packageJsonPath || this.config.build)  {
+			this.app.logger.log(` │ └── ${chalk.bold('Build system detected')}`)
 		}
 
 		if ( ! this.config.scripts ) {
 			this.config.scripts = {}
-		}
-		else {
-			this.config.buildEnabled = true
-			this.app.logger.log(` │ └── Build scripts detected in ${chalk.bold('package.json')}`)
+		} else {
+			let packagePath = './package.json';
+			if (this.config.packageJsonPath) {
+				packagePath = `./${this.config.packageJsonPath}/package.json`;
+			}
+			this.app.logger.log(` │ └── Build scripts detected in ${chalk.bold(packagePath)}`)
 		}
 
 		if ( ! this.config.autoWatch ) {
@@ -75,18 +81,18 @@ export class Client {
 	}
 
 	hasOneScript() {
-		return !!((this.hasBuildScript(ScriptMode.BUILD) || this.hasBuildScript(ScriptMode.WATCH) || this.hasBuildScript(ScriptMode.PROD)) && this.config.dist)
+		return !!((this.hasBuildScript(ScriptMode.BUILD) || this.hasBuildScript(ScriptMode.WATCH) || this.hasBuildScript(ScriptMode.PROD)) && this.config.www)
 	}
 
 	hasBuildScript(mode?:ScriptMode, script?:string) {
-		if ( ! this.config || ! this.config.src) {
+		if ( ! this.config || ! this.config.www || (this.config.www && ! this.config.build && ! this.config.packageJsonPath)) {
 			return false
 		}
 		try {
 			let pkgTxt = ''
-			if (fs.existsSync(path.join(this.app.path, this.config.src, 'package.json'))) {
-				pkgTxt = fs.readFileSync(path.join(this.app.path, this.config.src, 'package.json'), 'utf-8')
-				this.pkgPath = path.join(this.app.path, this.config.src)
+			if (fs.existsSync(path.join(this.app.path, this.config.packageJsonPath, 'package.json'))) {
+				pkgTxt = fs.readFileSync(path.join(this.app.path, this.config.packageJsonPath, 'package.json'), 'utf-8')
+				this.pkgPath = path.join(this.app.path, this.config.packageJsonPath)
 			}
 			else if (fs.existsSync(path.join(this.app.path, 'package.json'))) {
 				pkgTxt = fs.readFileSync(path.join(this.app.path, 'package.json'), 'utf-8')

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -26,24 +26,6 @@ export class Client {
 	load() {
 		this.app.logger.log(` └─┬ Client `)
 		this.config = this.app.config.get<IClientBuild>(this.app.mode, ConfigType.CLIENT);
-		/*if (fs.existsSync(path.join(this.app.path, '.materia', 'client.json'))) {
-			this.config = JSON.parse(fs.readFileSync(path.join(this.app.path, '.materia', 'client.json'), 'utf-8'))
-		}
-		const packageJson = JSON.parse(fs.readFileSync(path.join(this.app.path, 'package.json'), 'utf-8'))
-		if (packageJson && packageJson.scripts) {
-			if (!this.config.scripts) {
-				this.config.scripts = {}
-			}
-			if (! this.config.scripts.build) {
-				this.config.scripts.build = packageJson.scripts.build ? "build" : null;
-			}
-			if (! this.config.scripts.watch) {
-				this.config.scripts.watch = packageJson.scripts.watch ? "watch" : null;
-			}
-			if (! this.config.scripts.prod) {
-				this.config.scripts.prod = packageJson.scripts.prod ? "prod" : null;
-			}
-		}*/
 		if ( ! this.config ) {
 			this.config = { build: false }
 			this.app.logger.log(` │ └── ${chalk.bold('No build scripts detected')}`)
@@ -125,57 +107,4 @@ export class Client {
 		}
 		return false
 	}
-
-	/*set(src, build, scripts, autoWatch) {
-		this.config.src = src
-		this.config.build = build
-		// UPDATE STATIC FOLDER AT RUNTIME
-		this.app.server.dynamicStatic.setPath(path.join(this.app.path, build));
-		if ( ! this.config.scripts ) {
-			this.config.scripts = {}
-		}
-		this.config.scripts.build = scripts.build
-		this.config.scripts.watch = scripts.watch
-		this.config.scripts.prod = scripts.prod
-
-		this.config.autoWatch = autoWatch
-		this.watching = false
-		return this.save()
-	}
-
-	save() {
-		if ( this.config ) {
-			if ( this.config.src == 'client' && this.config.dist == 'client' && ! this.hasOneScript() ) {
-				return Promise.resolve()
-			}
-
-			let res = {
-				src: this.config.src,
-				scripts: {}
-			} as IClientConfig
-
-			if (this.config.dist != this.config.src && this.config.dist) {
-				res.dist = this.config.dist
-			}
-
-			if (this.hasBuildScript(ScriptMode.BUILD)) {
-				res.scripts.build = this.config.scripts.build
-			}
-
-			if (this.hasBuildScript(ScriptMode.PROD)) {
-				res.scripts.prod = this.config.scripts.prod
-			}
-
-			if (this.hasBuildScript(ScriptMode.WATCH)) {
-				res.scripts.watch = this.config.scripts.watch
-			}
-
-			if (this.config.autoWatch) {
-				res.autoWatch = this.config.autoWatch
-			}
-
-			fs.writeFileSync(path.join(this.app.path, '.materia', 'client.json'), JSON.stringify(res, null, 2))
-		}
-		return Promise.resolve()
-	}*/
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -74,6 +74,7 @@ export interface IConfigOptions {
 export class Config {
 	config: IFullConfig;
 
+	clientPackageJson: IPackageJson;
 	packageJson: IPackageJson;
 	materiaJson: IMateriaJson;
 	materiaProdJson: any;
@@ -140,6 +141,20 @@ export class Config {
 			);
 		} catch (e) {
 			this.entitiesPosition = {};
+		}
+
+		try {
+			const packageJsonPath = this.materiaJson.client && this.materiaJson.client.packageJsonPath ?
+			path.join(this.app.path, this.materiaJson.client.packageJsonPath, "package.json") :
+			path.join(this.app.path, "package.json");
+			this.clientPackageJson = JSON.parse(
+				fs.readFileSync(
+					packageJsonPath,
+					"utf-8"
+				)
+			);
+		} catch (e) {
+			this.clientPackageJson = this.packageJson;
 		}
 	}
 

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -154,10 +154,8 @@ export class Server {
 		// DEPRECATED or should call this.app.client.hasIndexFile() as it's not the concern of the server implementation to know about the client
 		const clientConfig: IClientConfig = this.app.config.get(this.app.mode, ConfigType.CLIENT);
 		let p;
-		if (clientConfig && clientConfig.dist) {
-			p = clientConfig.dist
-		} else if ( clientConfig && ! clientConfig.dist && clientConfig.src) {
-			p = clientConfig.src;
+		if (clientConfig && clientConfig.www) {
+			p = clientConfig.www
 		} else {
 			p = 'client';
 		}
@@ -177,10 +175,8 @@ export class Server {
 
 					let webDir;
 					// console.log(clientConfig);
-					if (clientConfig && clientConfig.dist) {
-						webDir = clientConfig.dist
-					} else if (clientConfig && !clientConfig.dist && clientConfig.src) {
-						webDir = clientConfig.src
+					if (clientConfig && clientConfig.www) {
+						webDir = clientConfig.www
 					} else {
 						webDir = 'client'
 					}
@@ -197,11 +193,11 @@ export class Server {
 					})
 
 					this.expressApp.all('/*', (req, res) => {
-						if (clientConfig && fs.existsSync(path.join(this.app.path, clientConfig.dist, '404.html'))) {
-							res.sendFile(path.join(this.app.path, clientConfig.dist, '404.html'))
+						if (clientConfig && fs.existsSync(path.join(this.app.path, clientConfig.www, '404.html'))) {
+							res.sendFile(path.join(this.app.path, clientConfig.www, '404.html'))
 						}
 						else if (this.hasStatic()) {
-							res.sendFile(path.join(this.app.path, clientConfig.dist, 'index.html'))
+							res.sendFile(path.join(this.app.path, clientConfig.www, 'index.html'))
 						}
 						else {
 							res.status(404).send({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@materia/interfaces@1.0.0-beta.1":
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@materia/interfaces/-/interfaces-1.0.0-beta.1.tgz#5c586f5fbc85c9ce0c7b3ae09a8e5fbcfa293903"
-  integrity sha512-FMy5pprmnqtl/52mStZPlqT6jJVJ/8gvGCVraca5G7kSNr29HWuvVEeqqpJ4ZdkLCM/3y8sYbtYbhAoTIhY+Pg==
+"@materia/interfaces@^1.0.0-beta.2":
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@materia/interfaces/-/interfaces-1.0.0-beta.2.tgz#403b9082cc4e95100843486a3ea0a0bf9c9bd90d"
+  integrity sha512-st2cPRGXkOGDKIdbsdehbDMqaqHfDzizrcX4/fRU5dT5gOeZiFs6IFJUTJSBWuwmnniHkAK7uYy8aQisQ9aHzA==
 
 "@types/bluebird@*":
   version "3.5.20"


### PR DESCRIPTION
This PR refac client config to match latest change in @materia/interfaces:
- new string key 'www': representing the relative path to the static folder being served in '/' (formerly 'src' or 'dist' depending if a build system was present or not)
- new string key 'packageJsonPath': optionnal key if a build system is present representing the relative path to the folder containing the client package.json (if the root package.json is used this key is optionnal)
- new boolean key 'build': only required if a build system is present and using the root package.json

Examples:
{'www': 'client'} => no build system, the application is serving a simple index.html file located in './client'
{'www': 'dist', 'build': true} => client with build system using the root package.json and the output bundle is located in './dist';
{'www': client/dist', 'build': true, 'packageJsonPath': 'client'} or {'www': 'client/dist', 'packageJsonPath: 'client'} => client with build system using the package.json located in './client' and the output bundle is located in './client/dist';