### PR TITLE
Fix angular/react boilerplates

### DIFF
--- a/src/api/lib/angular-cli.ts
+++ b/src/api/lib/angular-cli.ts
@@ -13,9 +13,12 @@ export class AngularCli {
 		return new Promise((resolve, reject) => {
 			let data = '';
 			let stream = null;
+			if ( ! cwd) {
+				cwd = this.app.path;
+			}
 			if (fs.existsSync(path.join(cwd, "node_modules", ".bin", "ng"))) {
 				stream = execa(path.join(cwd, "node_modules", ".bin", "ng"), [command, ...params], {
-					cwd: cwd ? cwd : this.app.path
+					cwd: cwd
 				});
 				stream.stdout.on('data', d => {
 					data += d;

--- a/src/api/lib/npx.ts
+++ b/src/api/lib/npx.ts
@@ -1,64 +1,53 @@
+import * as execa from 'execa';
+import * as which from 'which';
+
 import { App } from "../../lib";
 
-import * as path from 'path';
-import * as cp from 'child_process';
-
-import { buffer } from './buffer';
-import * as fs from 'fs';
-import * as execa from 'execa';
-
 export class Npx {
+
 	constructor(private app: App) {}
-
-	call(args, bufferized?: boolean) {
-		const cwd = this.app.path;
-
-		const npmPath = path.join(
-			__dirname,
-			'node_modules',
-			'npm',
-			'bin',
-			`npx-cli.js`
-		);
-		const proc = cp.fork(npmPath, args, {
-			cwd: cwd,
-			silent: true
-		});
-		if (bufferized) {
-			return buffer(proc);
-		} else {
-			return proc;
-		}
-	}
 
 	exec(command: string, params?: string[]): Promise<any> {
 		return new Promise((resolve, reject) => {
-			let data = '';
-			let stream = null;
-			if (fs.existsSync(path.resolve(`node_modules/.bin/npx`))) {
-				stream = execa(path.resolve(`node_modules/.bin/npx`), [command, ...params], {
+			return this._getNpxPath().then(npxPath => {
+				let data = '';
+				const stream = execa(npxPath, [command, ...params], {
 					cwd: this.app.path
 				});
-			} else {
-				stream = execa(path.join(path.resolve(), `resources/node_modules/.bin/npx`), [command, ...params], {
-					cwd: this.app.path
+				stream.stdout.on('data', d => {
+					data += d;
 				});
-			}
-			stream.stdout.on('data', d => {
-				data += d;
-			});
-			stream.stderr.on('data', (d) => {
-				data += d;
-			});
+				stream.stderr.on('data', (d) => {
+					data += d;
+				});
 
-			stream.on('close', (code) => {
-				if (code == 0) {
-					return resolve(data);
+				stream.on('close', (code) => {
+					if (code == 0) {
+						return resolve(data);
+					} else {
+						return reject({
+							code,
+							data
+						});
+					}
+				});
+			});
+		});
+	}
+
+	private _getNpxPath() {
+		return new Promise((resolve, reject) => {
+			which('npx', (err, npxPath) => {
+				if (err && ! npxPath) {
+					if (this.app) {
+						this.app.logger.error(`npx -> path error: ${err}`)
+					}
+					reject(err);
 				} else {
-					return reject({
-						code,
-						data
-					});
+					if (this.app) {
+						this.app.logger.log(`npx -> path: ${npxPath}`)
+					}
+					resolve(npxPath)
 				}
 			});
 		});


### PR DESCRIPTION
This PR fix:
- Angular boilerplate: fix a bug introduce in v1.0.0-beta.2 where angularCli.exec() will fail if cwd is not provided,
- React boilerplate: retrieve global npx path by using 'which' package like npm.