### PR TITLE
Fix CLI files end of line when publishing from a windows machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "chai-http": "^3.0.0",
+    "crlf": "^1.1.1",
     "mocha": "^3.2.0",
     "ncp": "^2.0.0",
     "request": "^2.79.0",
@@ -67,12 +68,14 @@
     "typescript": "^2.5.2"
   },
   "scripts": {
+    "build": "tsc -p . && ncp package.json dist/package.json && ncp src/cli dist/cli",
+    "prepublishOnly": "true || IF a==a crlf --set=LF cli/*",
+    "postpublish": "true || IF a==a crlf --set=CRLF cli/*",
     "test": "mocha -R spec dist/test/**/*.js",
     "test-watch": "mocha -R spec 'dist/test/**/*.js' --watch",
     "test-postgres": "DIALECT=postgres npm test",
     "test-sqlite": "npm test",
     "test-all": "npm run test-sqlite -s && npm run test-postgres -s",
-    "build": "tsc -p . && ncp package.json dist/package.json && ncp src/cli dist/cli",
     "watch": "tsc -p . -w"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,6 +836,14 @@ crc@3.4.4:
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.4.4.tgz#9da1e980e3bd44fc5c93bf5ab3da3378d85e466b"
   integrity sha1-naHpgOO9RPxck79as9ozeNheRms=
 
+crlf@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/crlf/-/crlf-1.1.1.tgz#24172841b4c83529a6aa4489df7eed958b2ed16f"
+  integrity sha1-JBcoQbTINSmmqkSJ337tlYsu0W8=
+  dependencies:
+    glub "^1.0.0"
+    transform-file "^1.0.1"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1565,6 +1573,17 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^5.0.5:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -1576,6 +1595,14 @@ glob@^7.0.5:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glub@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/glub/-/glub-1.0.3.tgz#56c1643298ae25065c6315003337bba69d2fb866"
+  integrity sha1-VsFkMpiuJQZcYxUAMze7pp0vuGY=
+  dependencies:
+    glob "^5.0.5"
+    minimist "^1.1.1"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
@@ -2385,7 +2412,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -2397,7 +2424,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -3859,6 +3886,13 @@ tough-cookie@~2.4.3:
   dependencies:
     psl "^1.1.24"
     punycode "^1.4.1"
+
+transform-file@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/transform-file/-/transform-file-1.0.1.tgz#7f95984acd23d4ebf8abb47ee9d83be166d12687"
+  integrity sha1-f5WYSs0j1Ov4q7R+6dg74WbRJoc=
+  dependencies:
+    os-tmpdir "^1.0.0"
 
 ts-node@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
This PR fix a bug where publishing @materia/server from a windows machine may replace cli files eol to CRLF instead of LF : 
- New crlf dev package
- Add prepublishOnly/postpublish scripts to replace eol CRLF to LF style on windows during npm publish