### PR TITLE
(Database) 'LIKE' condition operators enhancement

### DIFF
--- a/src/api/controllers/database.ctrl.ts
+++ b/src/api/controllers/database.ctrl.ts
@@ -270,6 +270,7 @@ export class DatabaseController {
 	listActions(req, res) {
 		res.status(200).json(this.app.actions.findAll())
 	}
+
 	addAction(req, res) {
 		DatabaseLib.generateActionId().then(id => {
 			const action = Object.assign({}, req.body, {
@@ -289,6 +290,7 @@ export class DatabaseController {
 			}
 		});
 	}
+
 	updateAction(req, res) {
 		const action = req.body;
 
@@ -305,6 +307,7 @@ export class DatabaseController {
 			});
 		}
 	}
+
 	removeAction(req, res) {
 		if (this.app.actions.remove(req.params.id, { save: true })) {
 			res.status(200).json(
@@ -401,7 +404,7 @@ export class DatabaseController {
 		return this.app.synchronizer.diff().then((diffs) => {
 			res.status(200).send(diffs);
 		}).catch(err => {
-			res.status(500).send(err)
+			res.status(500).send(err.message)
 		});
 
 	};
@@ -420,7 +423,7 @@ export class DatabaseController {
 			return this.app.synchronizer.databaseToEntities(diffs, null)
 				.then((result) =>
 					res.status(200).send(result)
-				).catch(err => res.status(500).send(err));
+				).catch(err => res.status(500).send(err.message));
 		} else {
 			return res.status(500).send(new Error(`Sync type '${type}' not found`));
 		}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -14,6 +14,7 @@ import { IDatabaseConfig, ISQLDatabase, ISQLiteDatabase } from '@materia/interfa
 
 import { DatabaseInterface } from './database/interface'
 import { MateriaError } from './error'
+import { Op } from 'Sequelize';
 
 export enum Dialect {
 	POSTGRES,
@@ -28,6 +29,7 @@ export interface ISequelizeConfig {
 	logging: any,
 	storage?: string
 	dialectOptions?: any
+	operatorsAliases?: {[alias: string]: any}
 }
 
 const dialect = {
@@ -105,18 +107,35 @@ export class Database {
 		this.started = false
 
 		let logging: any
-		if (this.app.options.logSql == true)
+		if (this.app.options.logSql == true) {
 			logging = (...args) => { this.app.logger.log.apply(this.app.logger, args) }
-		else if (this.app.options.logSql !== undefined)
+		}
+		else if (this.app.options.logSql !== undefined) {
 			logging = this.app.options.logSql
-		else
+		}
+		else {
 			logging = false
+		}
+
+		const operatorsAliases = {
+			$eq: Op.eq,
+			$ne: Op.ne,
+			$gte: Op.gte,
+			$gt: Op.gt,
+			$lte: Op.lte,
+			$lt: Op.lt,
+			$like: Op.like,
+			$notLike: Op.notLike,
+			$iLike: Op.iLike,
+			$notILike: Op.notILike
+		};
 
 		this.opts = {
  			dialect: this.type,
 			host: this.host,
 			port: this.port,
-			logging: logging
+			logging: logging,
+			operatorsAliases
 		}
 
 		if (Database.isSQLite(settings)) {

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -127,7 +127,10 @@ export class Database {
 			$like: Op.like,
 			$notLike: Op.notLike,
 			$iLike: Op.iLike,
-			$notILike: Op.notILike
+			$notILike: Op.notILike,
+			$and: Op.and,
+			$or: Op.or,
+			$not: Op.not
 		};
 
 		this.opts = {

--- a/src/lib/entities/queries/utils/conditions.ts
+++ b/src/lib/entities/queries/utils/conditions.ts
@@ -2,7 +2,7 @@ import { Condition, ICondition } from './condition'
 import { DBEntity } from '../../db-entity'
 
 import { Query, QueryParamResolver, IQueryParam } from '../../query'
-import { MateriaError } from '../../../error'
+import { MateriaError } from '../../../error';
 
 /*
 Conditions manage a list of condition (associated with `operand`)
@@ -20,7 +20,6 @@ Conditions structure:
 	}
 ]
 */
-
 
 const SequelizeOperatorsKeys = {
 	'=': '$eq',
@@ -71,14 +70,23 @@ export class Conditions {
 					let resolvedParam = QueryParamResolver.resolve(condition, params)
 					let opkey = SequelizeOperatorsKeys[condition.operator.toUpperCase()]
 					cond = {}
-					cond[opkey] = resolvedParam
+					if (
+						(condition.operator === 'LIKE'
+						|| condition.operator === 'ILIKE'
+						|| condition.operator === 'NOT LIKE'
+						|| condition.operator === 'NOT ILIKE')
+						&& resolvedParam.indexOf('%') === -1
+					) {
+						resolvedParam = `%${resolvedParam}%`;
+					}
+					cond[opkey] = resolvedParam;
 				}
 				cond = { [condition.name]: cond }
 
 				if (condition.operand && condition.operand.toUpperCase() == 'OR') {
-					$or.push(cond)
+					$or.push(cond);
 				} else {
-					$and.push(cond)
+					$and.push(cond);
 				}
 			}
 		}


### PR DESCRIPTION
This PR brings:
- Database Query 'LIKE' operators improvement:  '%' is now append at start/end of the provided param value if not already present,
- Sequelize Warning: remove string based operator deprecation warning.