### PR TITLE
(Server) Fix getBaseUrl mode

### DIFF
--- a/install_electron.sh
+++ b/install_electron.sh
@@ -3,7 +3,7 @@
 sudo rm -rf node_modules/
 
 # Electron's version.
-export npm_config_target=2.0.0-beta.1
+export npm_config_target=2.0.0
 # The architecture of Electron, can be ia32 or x64.
 export npm_config_arch=x64
 export npm_config_target_arch=x64

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -116,6 +116,7 @@ export class Server {
 	*/
 	getBaseUrl(path?: string, mode?: AppMode, options?: IConfigOptions) {
 		path = path || '/api'
+		mode = mode || this.app.mode;
 		let appConf = this.app.config.get<IAppConfig>(
 			mode,
 			ConfigType.APP,


### PR DESCRIPTION
In getBaseUrl method, when `mode` (2nd argument) is not passed, it was not looking at the current server mode (which was breaking the condition for production environment L125). Now, when mode is empty, it takes `this.app.mode` by default.