### PR TITLE
Admin API Rest: Addons endpoints enhancement

### DIFF
--- a/src/api/controllers/addons.ctrl.ts
+++ b/src/api/controllers/addons.ctrl.ts
@@ -5,6 +5,18 @@ import * as fs from 'fs';
 export class AddonsController {
 	constructor(private app: App, websocket: WebsocketInstance) {}
 
+	getConfig(req, res) {
+		let pkg = req.params.pkg;
+		if (req.params[0]) {
+			pkg += req.params[0];
+		}
+		if (! pkg || ! this.app.addons.get(pkg)) {
+			res.status(404).send();
+		} else {
+			res.status(200).send(this.app.addons.addonsConfig[pkg]);
+		}
+	}
+
 	setup(req, res) {
 		this.app.watcher.disable();
 		const pkg = this.getPkgFromRequest(req);

--- a/src/api/controllers/addons.ctrl.ts
+++ b/src/api/controllers/addons.ctrl.ts
@@ -6,10 +6,7 @@ export class AddonsController {
 	constructor(private app: App, websocket: WebsocketInstance) {}
 
 	getConfig(req, res) {
-		let pkg = req.params.pkg;
-		if (req.params[0]) {
-			pkg += req.params[0];
-		}
+		const pkg = this.getPkgFromRequest(req);
 		if (! pkg || ! this.app.addons.get(pkg)) {
 			res.status(404).send();
 		} else {
@@ -65,8 +62,10 @@ export class AddonsController {
 		}
 	}
 	private getPkgFromRequest(req) {
-		return req.params.owner
-			? `${req.params.owner}/${req.params.pkg}`
-			: req.params.pkg;
+		let pkg = req.params.pkg;
+		if (req.params[0]) {
+			pkg += req.params[0];
+		}
+		return pkg;
 	}
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -189,20 +189,11 @@ export class MateriaApi {
 		/**
 		 * Addon Endpoints
 		 */
-
-		this.api.get('/materia/addons/:pkg/bundle.js', this.addonsCtrl.bundle.bind(this.addonsCtrl))
-		this.api.get('/materia/addons/:owner/:pkg/bundle.js', this.addonsCtrl.bundle.bind(this.addonsCtrl))
-
+		this.api.get('/materia/addons/:pkg*/bundle.js', this.addonsCtrl.bundle.bind(this.addonsCtrl))
 		this.api.get('/materia/addons/:pkg*/setup', this.oauth.isAuth, this.addonsCtrl.getConfig.bind(this.addonsCtrl));
-
-		this.api.post('/materia/addons/:pkg/setup', this.oauth.isAuth, this.addonsCtrl.setup.bind(this.addonsCtrl));
-		this.api.post('/materia/addons/:owner/:pkg/setup', this.oauth.isAuth, this.addonsCtrl.setup.bind(this.addonsCtrl));
-
-		this.api.post('/materia/addons/:pkg/enable', this.oauth.isAuth, this.addonsCtrl.enable.bind(this.addonsCtrl));
-		this.api.post('/materia/addons/:owner/:pkg/enable', this.oauth.isAuth, this.addonsCtrl.enable.bind(this.addonsCtrl));
-
-		this.api.post('/materia/addons/:pkg/disable', this.oauth.isAuth, this.addonsCtrl.disable.bind(this.addonsCtrl));
-		this.api.post('/materia/addons/:owner/:pkg/disable', this.oauth.isAuth, this.addonsCtrl.disable.bind(this.addonsCtrl));
+		this.api.post('/materia/addons/:pkg*/setup', this.oauth.isAuth, this.addonsCtrl.setup.bind(this.addonsCtrl));
+		this.api.post('/materia/addons/:pkg*/enable', this.oauth.isAuth, this.addonsCtrl.enable.bind(this.addonsCtrl));
+		this.api.post('/materia/addons/:pkg*/disable', this.oauth.isAuth, this.addonsCtrl.disable.bind(this.addonsCtrl));
 
 		/**
 		 * Client Endpoints

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -193,6 +193,8 @@ export class MateriaApi {
 		this.api.get('/materia/addons/:pkg/bundle.js', this.addonsCtrl.bundle.bind(this.addonsCtrl))
 		this.api.get('/materia/addons/:owner/:pkg/bundle.js', this.addonsCtrl.bundle.bind(this.addonsCtrl))
 
+		this.api.get('/materia/addons/:pkg*/setup', this.oauth.isAuth, this.addonsCtrl.getConfig.bind(this.addonsCtrl));
+
 		this.api.post('/materia/addons/:pkg/setup', this.oauth.isAuth, this.addonsCtrl.setup.bind(this.addonsCtrl));
 		this.api.post('/materia/addons/:owner/:pkg/setup', this.oauth.isAuth, this.addonsCtrl.setup.bind(this.addonsCtrl));
 


### PR DESCRIPTION
This PR brings:
- New endpoint : GET `/materia/addons/:pkg*/setup` => Get addon config with pkg name,
- Remove duplicated endpoints to handle package name with owner => use `:pkg*` notation in url instead.