### PR TITLE
Permissions management enhancement

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "./swagger.json",
+        url: "./openapi.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1976,22 +1976,13 @@
 					"200": {
 						"description": "Success"
 					}
-				}
-			}
-		},
-		"/permissions/new": {
-			"post": {
-				"tags": ["Api"],
-				"summary": "Generate a new permission file",
-				"responses": {
-					"200": {
-						"description": "Success"
-					}
 				},
 				"requestBody": {
 					"content": {
 						"application/json": {
 							"schema": {
+								"required": ["name", "file"],
+								"uniqueItems": true,
 								"properties": {
 									"name": {
 										"type": "string",
@@ -2005,8 +1996,13 @@
 									},
 									"description": {
 										"type": "string",
-										"description": "Description of the permission to add",
+										"description": " Description of the permission to add",
 										"example": "Only connected user are allowed"
+									},
+									"code": {
+										"type": "string",
+										"description": "Middleware function",
+										"example": "module.exports = (req, res, next) => { if (req.user) { return next(); } return next(new Error('Unauthorized');}"
 									}
 								}
 							}
@@ -2018,7 +2014,7 @@
 		"/permissions/:permission": {
 			"put": {
 				"tags": ["Api"],
-				"summary": "Update permission code content",
+				"summary": "Update a permission",
 				"responses": {
 					"200": {
 						"description": "Success"
@@ -2028,7 +2024,7 @@
 					"name": "permission",
 					"in": "path",
 					"required": true,
-					"description": "Permission name to update",
+					"description": "The permission's name before update",
 					"schema": {
 						"type": "string"
 					}
@@ -2037,30 +2033,27 @@
 					"content": {
 						"application/json": {
 							"schema": {
+								"required": ["name", "file"],
 								"properties": {
-									"permission": {
-										"properties": {
-											"name": {
-												"type": "string",
-												"description": "Name of the permission",
-												"example": "Connected User Renamed"
-											},
-											"file": {
-												"type": "string",
-												"description": "Filename of the permission",
-												"example": "connected-user"
-											},
-											"description": {
-												"type": "string",
-												"description": "Description of the permission",
-												"example": "Only connected user are allowed"
-											}
-										}
-									},
-									"oldName": {
+									"name": {
 										"type": "string",
-										"description": "Name of the permission before update",
-										"example": "Connected User"
+										"description": "New name of the permission",
+										"example": "Connected User Renamed"
+									},
+									"file": {
+										"type": "string",
+										"description": "New filename of the permission",
+										"example": "connected-user"
+									},
+									"description": {
+										"type": "string",
+										"description": "New description of the permission",
+										"example": "Only connected user are allowed"
+									},
+									"code": {
+										"type": "string",
+										"description": "Middleware function",
+										"example": "module.exports = (req, res, next) => { if (req.user) { return next(); } return next(new Error('Unauthorized');}"
 									}
 								}
 							}
@@ -2080,7 +2073,25 @@
 					"name": "permission",
 					"in": "path",
 					"required": true,
-					"description": "Permission name to delete",
+					"description": "Permission's name to delete",
+					"schema": {
+						"type": "string"
+					}
+				}]
+			},
+			"get": {
+				"tags": ["Api"],
+				"summary": "Get a permission",
+				"responses": {
+					"200": {
+						"description": "Success"
+					}
+				},
+				"parameters": [{
+					"name": "permission",
+					"in": "path",
+					"required": true,
+					"description": "Permission's name to get",
 					"schema": {
 						"type": "string"
 					}

--- a/src/api/controllers/git.ctrl.ts
+++ b/src/api/controllers/git.ctrl.ts
@@ -80,7 +80,7 @@ export class GitController {
 		this.client.pull(req.body.remote, req.body.branch).then(data => {
 			res.status(200).send(data);
 		}).catch(err => {
-			res.status(500).send(err);
+			res.status(500).send(err.message);
 		})
 	}
 

--- a/src/api/controllers/permissions.ctrl.ts
+++ b/src/api/controllers/permissions.ctrl.ts
@@ -60,6 +60,17 @@ export class PermissionsController {
 		}
 	}
 
+	get(req, res) {
+		const name = req.params.permission;
+		const permissions = PermissionsLib.list(this.app);
+		const permission = permissions.find(p => p.name === name);
+		if (permission) {
+			res.status(200).send(permission);
+		} else {
+			res.status(500).send(`Permission with name '${name}' not found`);
+		}
+	}
+
 	list(req, res) {
 		res.status(200).json(PermissionsLib.list(this.app));
 	}

--- a/src/api/controllers/permissions.ctrl.ts
+++ b/src/api/controllers/permissions.ctrl.ts
@@ -53,7 +53,7 @@ export class PermissionsController {
 						selected: newPermission.name
 					});
 				})
-				.catch(err => res.status(500).json(err))
+				.catch(err => res.status(500).send(err.message))
 			});
 		} else {
 			res.status(500).send(`The permission "${newPermission.name}" already exists`);
@@ -101,10 +101,10 @@ export class PermissionsController {
 		const oldName = req.params.permission;
 		const oldPermission = this.app.api.permissions.get(oldName);
 		if ( ! oldPermission) {
-			return res.status(500).json(new Error('Impossible to update: no permission selected'));
+			return res.status(500).send('Impossible to update: no permission selected');
 		}
 		if (oldPermission.readOnly) {
-			return res.status(500).json(new Error('Impossible to update: permission is in readonly'));
+			return res.status(500).send('Impossible to update: permission is in readonly');
 		}
 		let promise = Promise.resolve();
 		if (oldPermission.name !== permission.name || oldPermission.description !== permission.description || oldPermission.file !== permission.file) {
@@ -132,7 +132,7 @@ export class PermissionsController {
 				permissions: PermissionsLib.list(this.app),
 				selected: updatedPermission.name
 			});
-		}).catch(err => res.status(500).json(err));;
+		}).catch(err => res.status(500).send(err.message));;
 	}
 
 	private _checkNewPermission(perm): Promise<string> {

--- a/src/api/controllers/permissions.ctrl.ts
+++ b/src/api/controllers/permissions.ctrl.ts
@@ -1,95 +1,72 @@
 import * as path from 'path';
 import * as fs from 'fs';
 
-import { App } from '../../lib';
+import { App, Permission } from '../../lib';
 import { WebsocketInstance } from '../../lib/websocket';
+import { IPermission } from '@materia/interfaces';
 
 export class PermissionsController {
 
 	constructor(private app: App, websocket: WebsocketInstance) {}
 
-	initCreate(req, res) {
-		const perm = req.body;
-		let middleware;
-		this._checkNewPermission(perm).then(result => {
-			if (result !== '') {
-				try {
-					let file = path.join(
-						this.app.path,
-						'server',
-						'permissions',
-						perm.file
-					);
-					let rp = require.resolve(file);
-					if (require.cache[rp]) {
-						delete require.cache[rp];
+	add(req, res) {
+		const newPermission: IPermission = req.body;
+		const exists: boolean = this.app.api.permissions.findAll().findIndex(p => p.name === newPermission.name) !== -1;
+		if ( ! exists) {
+			let middleware = this._getDefaultMiddleware();
+			this._checkNewPermission(newPermission).then((permissionCode) => {
+				if (permissionCode !== '') {
+					try {
+						let file = path.join(
+							this.app.path,
+							'server',
+							'permissions',
+							newPermission.file
+						);
+						let rp = require.resolve(file);
+						if (require.cache[rp]) {
+							delete require.cache[rp];
+						}
+						middleware = require(file);
+					} catch (err) {}
+				}
+
+				this.app.api.permissions.add(
+					{
+						name: newPermission.name,
+						description: newPermission.description,
+						middleware: newPermission.code ? eval(newPermission.code) : middleware,
+						file: newPermission.file
+					},
+					{ save: true }
+				)
+				.then((result) => {
+					const reloadPerm = this.app.api.permissions
+						.get(newPermission.name);
+
+					if (reloadPerm) {
+						reloadPerm.reload();
 					}
-					middleware = require(file);
-				}
-				catch {
-					middleware = (req, res, next) => {
-	next();
-};
-				}
-			} else {
-				middleware = (req, res, next) => {
-	next();
-};
-			}
-			this.app.api.permissions
-			.add(
-				{
-					name: perm.name,
-					description: perm.description,
-					middleware: middleware,
-					file: perm.file
-				},
-				{ save: true }
-			)
-			.then(result => {
-				const reloadPerm = this.app.api.permissions
-					.get(perm.name);
 
-				if (reloadPerm) {
-					reloadPerm.reload();
-				}
-
-				res.status(200).json({
-					permissions: PermissionsLib.list(this.app),
-					selected: perm.name
-				});
-			})
-			.catch(err => res.status(500).json(err));
-		})
+					res.status(200).json({
+						permissions: PermissionsLib.list(this.app),
+						selected: newPermission.name
+					});
+				})
+				.catch(err => res.status(500).json(err))
+			});
+		} else {
+			res.status(500).send(`The permission "${newPermission.name}" already exists`);
+		}
 	}
 
-	update(req, res) { // payload: { permission: IPermission; oldName: string }) {
-		const perm = req.body;
-		const oldName = req.params.permission;
-		return this.app.api.permissions
-			.update(
-				oldName,
-				{
-					name: perm.name,
-					description: perm.description,
-					file: perm.file
-				},
-				{ save: true }
-			)
-			.then(result => {
-				const reloadPerm = this.app.api.permissions.get(perm.name);
-				reloadPerm.reload();
-				res.status(200).json({
-					permissions: PermissionsLib.list(this.app),
-					selected: perm.name
-				});
-			})
-			.catch(err => res.status(500).json(err));
+	list(req, res) {
+		res.status(200).json(PermissionsLib.list(this.app));
 	}
 
-	remove(req, res) { // payload: { permission: IPermission; action: string }) {
+	remove(req, res) {
 		const perm = req.params.permission;
-		const action = req.query.action;
+		const action = req.query.action ? req.query.action : 'confirm and keep';
 		const reloadPerm = this.app.api.permissions.get(perm);
 		if (reloadPerm) {
 			reloadPerm.reload();
@@ -108,51 +85,46 @@ export class PermissionsController {
 		res.status(200).json(PermissionsLib.list(this.app));
 	}
 
-	save(req, res) {
-		const perm = this.app.api.permissions.get(req.body.name)
-			? this.app.api.permissions.get(req.body.name)
-			: req.body;
-		let filename = perm.file;
-		if (filename.indexOf(path.sep) == -1) {
-			filename = path.join(
-				this.app.path,
-				'server',
-				'permissions',
-				perm.file
-			);
+	update(req, res) {
+		const permission : IPermission = req.body;
+		const oldName = req.params.permission;
+		const oldPermission = this.app.api.permissions.get(oldName);
+		if ( ! oldPermission) {
+			return res.status(500).json(new Error('Impossible to update: no permission selected'));
 		}
-		if (filename.indexOf('.js') == -1) {
-			filename = filename + '.js';
+		if (oldPermission.readOnly) {
+			return res.status(500).json(new Error('Impossible to update: permission is in readonly'));
 		}
-
-		if (!perm) {
-			return res.status(500).json(new Error('Impossible to save: no permission selected'));
+		let promise = Promise.resolve();
+		if (oldPermission.name !== permission.name || oldPermission.description !== permission.description || oldPermission.file !== permission.file) {
+			promise = promise.then(() => this.app.api.permissions
+			.update(
+				oldName,
+				{
+					name: permission.name,
+					description: permission.description,
+					file: permission.file
+				},
+				{ save: true }
+			));
 		}
-		if (perm.readOnly) {
-			return res.status(500).json(new Error('Impossible to save: permission is in readonly'));
-		}
-
-		return this.app
-			.saveFile(filename, req.body.code, {
+		if (permission.code) {
+			const filename = this._getPermissionFilepath(this.app.api.permissions.get(permission.name));
+			promise = promise.then(() => this.app.saveFile(filename, permission.code, {
 				mkdir: true
-			})
-			.then(() => {
-				const reloadPerm = this.app.api.permissions.get(perm.name);
-				if (reloadPerm) {
-					reloadPerm.reload();
-				}
-				res.status(200).json(PermissionsLib.list(this.app));
-			})
-			.catch(err => {
-				res.status(500).json(err);
+			}));
+		}
+		return promise.then(() => {
+			const updatedPermission = this.app.api.permissions.get(permission.name);
+			updatedPermission.reload();
+			res.status(200).json({
+				permissions: PermissionsLib.list(this.app),
+				selected: updatedPermission.name
 			});
+		}).catch(err => res.status(500).json(err));;
 	}
 
-	list(req, res) {
-		res.status(200).json(PermissionsLib.list(this.app));
-	}
-
-	private _checkNewPermission(perm) {
+	private _checkNewPermission(perm): Promise<string> {
 		return new Promise((resolve, reject) => {
 			const filepath = path.join(
 				this.app.path,
@@ -165,9 +137,31 @@ export class PermissionsController {
 				if (err && err.code === 'ENOENT') {
 					return resolve('');
 				}
-				return resolve(fs.readFileSync(filepath));
+				return resolve(fs.readFileSync(filepath, 'utf-8'));
 			});
 		});
+	}
+
+	private _getDefaultMiddleware() {
+		return (req, res, next) => {
+			next();
+		};
+	}
+
+	private _getPermissionFilepath(permission: Permission) {
+		let filename = permission.file;
+		if (filename.indexOf(path.sep) == -1) {
+			filename = path.join(
+				this.app.path,
+				'server',
+				'permissions',
+				permission.file
+			);
+		}
+		if (filename.indexOf('.js') == -1) {
+			filename = filename + '.js';
+		}
+		return filename;
 	}
 }
 

--- a/src/api/controllers/permissions.ctrl.ts
+++ b/src/api/controllers/permissions.ctrl.ts
@@ -1,10 +1,11 @@
-import { App } from '../../lib';
-
 import * as path from 'path';
 import * as fs from 'fs';
+
+import { App } from '../../lib';
 import { WebsocketInstance } from '../../lib/websocket';
 
 export class PermissionsController {
+
 	constructor(private app: App, websocket: WebsocketInstance) {}
 
 	initCreate(req, res) {
@@ -153,7 +154,7 @@ export class PermissionsController {
 
 	private _checkNewPermission(perm) {
 		return new Promise((resolve, reject) => {
-			const filepath = 	path.join(
+			const filepath = path.join(
 				this.app.path,
 				'server',
 				'permissions',

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -184,6 +184,7 @@ export class MateriaApi {
 		 * Endpoints Permissions
 		 */
 		this.api.get('/materia/permissions', this.oauth.isAuth, this.permissionsCtrl.list.bind(this.permissionsCtrl));
+		this.api.get('/materia/permissions/:permission', this.oauth.isAuth, this.permissionsCtrl.get.bind(this.permissionsCtrl));
 		this.api.post('/materia/permissions', this.oauth.isAuth, this.permissionsCtrl.add.bind(this.permissionsCtrl));
 		this.api.put('/materia/permissions/:permission', this.oauth.isAuth, this.permissionsCtrl.update.bind(this.permissionsCtrl));
 		this.api.delete('/materia/permissions/:permission', this.oauth.isAuth, this.permissionsCtrl.remove.bind(this.permissionsCtrl));

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -184,8 +184,7 @@ export class MateriaApi {
 		 * Endpoints Permissions
 		 */
 		this.api.get('/materia/permissions', this.oauth.isAuth, this.permissionsCtrl.list.bind(this.permissionsCtrl));
-		this.api.post('/materia/permissions/new', this.oauth.isAuth, this.permissionsCtrl.initCreate.bind(this.permissionsCtrl));
-		this.api.post('/materia/permissions', this.oauth.isAuth, this.permissionsCtrl.save.bind(this.permissionsCtrl));
+		this.api.post('/materia/permissions', this.oauth.isAuth, this.permissionsCtrl.add.bind(this.permissionsCtrl));
 		this.api.put('/materia/permissions/:permission', this.oauth.isAuth, this.permissionsCtrl.update.bind(this.permissionsCtrl));
 		this.api.delete('/materia/permissions/:permission', this.oauth.isAuth, this.permissionsCtrl.remove.bind(this.permissionsCtrl));
 

--- a/src/lib/api/permission.ts
+++ b/src/lib/api/permission.ts
@@ -17,6 +17,7 @@ export class Permission {
 	readOnly: boolean = false;
 	middleware: any;
 	file: string;
+	invalid: boolean;
 
 	constructor(app, data: IPermission) {
 		this.app = app;
@@ -31,15 +32,18 @@ export class Permission {
 		if (data.middleware) {
 			this.middleware = data.middleware;
 		}
+		if (data.invalid) {
+			this.invalid = data.invalid;
+		}
 	}
 
-	reload() {
+	reload(): Promise<void> {
 		if (this.file) {
 			let file = this.file;
 			if (
 				this.file.indexOf(
 					path.join(this.app.path, 'server', 'permissions')
-				) == -1
+				) === -1
 			) {
 				file = path.join(
 					this.app.path,

--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -107,7 +107,10 @@ export class Permissions {
 		}
 	}
 
-	load(): Promise<any> {
+	/**
+	Load all the registered permissions
+	 */
+	load(): Promise<void> {
 		this.clear();
 		let permissionsPath, resolvedPath, permissionsRaw;
 		try {
@@ -131,7 +134,7 @@ export class Permissions {
 				results.push(this.add(obj));
 			});
 			return Promise.all(results).then(() => {
-				return true;
+				return;
 			});
 		} else {
 			return Promise.resolve();

--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -370,10 +370,11 @@ export class Permissions {
 			};
 		}
 		catch (e) {
+			const code = fs.existsSync(permissionPath + 'js') ? fs.readFileSync(permissionPath + '.js', 'utf8') : null;
 			return {
 				name: permission.name,
 				description: permission.description,
-				middleware: fs.readFileSync(permissionPath + '.js', 'utf8'),
+				middleware: code,
 				invalid: true,
 				file: permissionPath
 			};

--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -18,8 +18,6 @@ export class Permissions {
 		this.clear();
 	}
 
-	isAuthorized(permission) {}
-
 	check(permissionsName: Array<string>) {
 		return (req, res, next) => {
 			let chain = (req, res, next) => {


### PR DESCRIPTION
This PR brings:
- Admin API enhancement:
   - Single url to create/update permission infos/code,
   - New GET 'materia/permissions/:permission' endpoint to retrieve single permission by name,
   - Update related endpoints when a permission name is changed.
- Lib : Handle invalid permission with missing file + add/update method comment (docs),
- Related swagger documentation update.