### PR TITLE
(API) Handle Websocket endpoints in api.json

### DIFF
--- a/src/lib/api/endpoint.ts
+++ b/src/lib/api/endpoint.ts
@@ -269,8 +269,8 @@ export class Endpoint {
 		return { resolvedParams, errors }
 	}
 
-	handle(req, res, next):Promise<any> {
-		this.app.logger.log(`${chalk.bold('(Endpoint)')} Handle ${this.app.api.getMethodColor(req.method.toUpperCase())} ${chalk.bold(req.url)}`)
+	private handleHttp(req, res, next): Promise<any> {
+		this.app.logger.log(`${chalk.bold('(Endpoint)')} Handle ${this.app.api.getMethodColor(this.method.toUpperCase())} ${chalk.bold(req.url)}`)
 
 		let params = this.handleParams(req, this.params)
 
@@ -373,6 +373,26 @@ export class Endpoint {
 						})
 				}
 			})
+		}
+	}
+
+	private handleWS(wss): Promise<any> {
+		if (this.controller && this.action) {
+			try {
+				let instance = this._getController().instance()
+				this.app.logger.log(` └── Execute: (Controller) ${chalk.bold(instance.constructor.name)}.${chalk.bold(this.action)}\n`)
+				instance[this.action](wss)
+			} catch (e) {
+			}
+		}
+		return Promise.resolve();
+	}
+
+	handle(req, res, next):Promise<any> {
+		if (this.method.toLowerCase() !== 'ws') {
+			return this.handleHttp(req, res, next);
+		} else {
+			return this.handleWS(req);
 		}
 	}
 

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -44,7 +44,6 @@ export class WebsocketServers {
 			const urlParsed = url.parse(request.url);
 			const pathname = urlParsed.pathname;
 			if (this.servers[pathname] && this.servers[pathname].instance) {
-				this.servers[pathname].instance.close()
 				this.servers[pathname].instance.handleUpgrade(request, socket, head, ws => {
 					this.servers[pathname].instance.emit('connection', ws, request)
 				})

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -44,10 +44,9 @@ export class WebsocketServers {
 			const urlParsed = url.parse(request.url);
 			const pathname = urlParsed.pathname;
 			if (this.servers[pathname] && this.servers[pathname].instance) {
-
 				this.servers[pathname].instance.close()
 				this.servers[pathname].instance.handleUpgrade(request, socket, head, ws => {
-					this.servers[pathname].instance.emit('connection', ws)
+					this.servers[pathname].instance.emit('connection', ws, request)
 				})
 			}
 		});


### PR DESCRIPTION
This PR allow users to add endpoint in api.json with `ws` method.

e.g.
```
{
   "method": "ws",
   "url": "/test",
   "controller": "main",
   "action": "websocket",
}
```

The action `websocket` in the `main` controller can be defined as bellow:

```
class mainCtrl {
    constructor(app) {
        this.app = app;
    }

    websocket(wss) {
        wss.instance.on('connection', ws => {
            ws.on('message', (message) => {
                console.log('received: %s', message);
                wss.broadcast(message);
            });

            ws.send('something');
        });
    }
}

module.exports = mainCtrl;
```