### PR TITLE
Fix db-synchronizer 'entities to database' failing for delete_entity operation

### DIFF
--- a/src/lib/entities.ts
+++ b/src/lib/entities.ts
@@ -451,10 +451,6 @@ export class Entities {
 
 		const entity = this.entities[name];
 
-		if ( ! entity) {
-			return Promise.reject(new MateriaError(`Entity "${name}" does not exist.`));
-		}
-
 		const endpoints: IEndpoint[] = this.app.api.findAll().map(e => e.toJson());
 		const relatedEndpoints: IEndpoint[] = endpoints.filter((e: IEndpoint) => e.query && e.query.entity === name);
 		for (const endpoint of relatedEndpoints) {

--- a/src/test/integration/db-synchronizer-database-to-entities.test.ts
+++ b/src/test/integration/db-synchronizer-database-to-entities.test.ts
@@ -10,7 +10,7 @@ chai.config.truncateThreshold = 500;
 chai.use(chaiAsPromised);
 chai.should();
 
-describe('[Database synchronizer]', () => {
+describe('[Database synchronizer: from database to entities]', () => {
 	let app: App;
 	const tmpl = new TemplateApp('empty-app');
 	const primaryFieldDefault = {
@@ -73,7 +73,7 @@ describe('[Database synchronizer]', () => {
 				});
 		});
 
-		it('Database should have diffs', () => {
+		it('Database should have diffs after deleting "test.json" model file', () => {
 			return fse
 				.remove(
 					path.join(app.path, 'server', 'models', 'test.json')
@@ -122,7 +122,7 @@ describe('[Database synchronizer]', () => {
 				});
 		});
 
-		it('Synchronizing should re-add test model file with same intial property', () => {
+		it('Synchronizing "from database to entities" should re-add test model file with same intial property', () => {
 			return app.synchronizer.diff()
 			.then((diffs) => {
 				return app.synchronizer.databaseToEntities(diffs, null);

--- a/src/test/integration/db-synchronizer-entities-to-database.test.ts
+++ b/src/test/integration/db-synchronizer-entities-to-database.test.ts
@@ -1,0 +1,128 @@
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as fse from 'fs-extra';
+import * as path from 'path';
+
+import { App } from '../../lib/app';
+import { TemplateApp } from '../mock/template-app';
+
+chai.config.truncateThreshold = 500;
+chai.use(chaiAsPromised);
+chai.should();
+
+describe('[Database synchronizer: from entities to database]', () => {
+	let app: App;
+	const tmpl = new TemplateApp('empty-app');
+	const primaryFieldDefault = {
+		autoIncrement: true,
+		primary: true,
+		read: true,
+		required: true,
+		type: 'number',
+		unique: true,
+		write: false
+	};
+
+	before(() => {
+		tmpl.beforeCreate(new_app => {
+			new_app.server.disabled = true;
+		});
+		return tmpl.runApp().then(_app => (app = _app));
+	});
+
+	describe('App', () => {
+		it('should prepare entities "test"', () => {
+			return app.entities
+				.add({
+					name: 'test',
+					id: 'fake-id',
+					fields: [
+						{
+							name: 'id_test',
+							type: 'number',
+							read: true,
+							write: false,
+							primary: true,
+							unique: true,
+							required: true,
+							autoIncrement: true,
+							component: 'input'
+						}
+					]
+				})
+				.then(() =>
+					app.entities
+						.get('test')
+						.getField('id_test').toJson()
+				)
+				.should.become({
+					name: 'id_test',
+					component: 'input',
+					...primaryFieldDefault
+				});
+		});
+
+		it('Database should have only one table test', () => {
+			return app.database.sequelize.getQueryInterface().showAllTables()
+				.should.become(['test']);
+		});
+
+		it('Database should have diffs after deleting "test.json" model file', () => {
+			return fse
+				.remove(
+					path.join(app.path, 'server', 'models', 'test.json')
+				)
+				.then(() => {
+					return app.stop();
+				})
+				.then(() => {
+					return app.load();
+				})
+				.then(() => {
+					return app.start();
+				})
+				.then(() => {
+					return app.synchronizer.diff();
+				})
+				.should.become({
+					entities: [
+						{
+							redo: {
+								table: 'test',
+								type: 'create_entity',
+								value: {
+									fields: [
+										{
+											name: 'id_test',
+											default: false,
+											...primaryFieldDefault
+										}
+									],
+									isRelation: undefined,
+									name: 'test',
+									queries: [],
+									relations: []
+								}
+							},
+							undo: {
+								table: 'test',
+								type: 'delete_entity'
+							}
+						}
+					],
+					fields: [],
+					relations: [],
+					length: 1
+				});
+		});
+
+		it('Synchronizing "from database to entities" should delete table test from database', () => {
+			return app.synchronizer.diff()
+			.then((diffs) => {
+				return app.synchronizer.entitiesToDatabase(diffs, null);
+			}).then(() => {
+				return app.database.sequelize.getQueryInterface().showAllTables()
+			}).should.become([])
+		});
+	});
+});


### PR DESCRIPTION
This PR fix a bug where delete_entity operation fails when syncing database from entities and brings a new test file for testing the db-synchronizer with "entities to database" direction. Precedent test file was only testing "database to entities" direction.