### PR TITLE
(Server) Add bodyParser options in materia.json

### DIFF
--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -41,17 +41,17 @@ export class Server {
 	}
 
 	load() {
+		const conf = this.app.config.get<IServerConfig>(this.app.mode, ConfigType.SERVER);
+
 		this.expressApp = express();
-		this.expressApp.use(bodyParser.urlencoded({ extended: false }));
-		this.expressApp.use(bodyParser.json());
+		this.expressApp.use(bodyParser.urlencoded(Object.assign({}, { extended: false }, conf.bodyParser && conf.bodyPaser.urlencoded || {})));
+		this.expressApp.use(bodyParser.json(conf.bodyParser && conf.bodyParser.json));
 		this.expressApp.use(methodOverride());
 		this.expressApp.use(compression());
 
 		if ((this.app.mode == AppMode.DEVELOPMENT || this.app.options.logRequests) && this.app.options.logRequests != false) {
 			this.expressApp.use(morgan('dev'));
 		}
-
-		const conf = this.app.config.get<IServerConfig>(this.app.mode, ConfigType.SERVER);
 		if (conf.cors == null || conf.cors) {
 			this.expressApp.use(function (req, res, next) {
 				res.header('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
Add options to configure bodyParser middleware in materia.json:

```
{
   // ...
   server: {
      // ...
      bodyParser: {
         urlencoded: {
            // options for bodyParser.urlencoded()
         },
         json: {
            // options for bodyParser.json()
         }
      }
   }
}
```

Options are described here: https://www.npmjs.com/package/body-parser

bodyParser configuration is optional.

This commit from @materia/interfaces is required: https://github.com/materiahq/materia-interfaces/commit/b2d1fde228cca915d1e82323e001fa06de7a7e2e